### PR TITLE
[codex] Add shared hardcoded project translations

### DIFF
--- a/resources/frontend-hardcoded-zh-CN.json
+++ b/resources/frontend-hardcoded-zh-CN.json
@@ -1,0 +1,13 @@
+[
+  ["title:\"Projects\"", "title:\"项目\""],
+  ["label:\"Projects\"", "label:\"项目\""],
+  ["children:\"Projects\"", "children:\"项目\""],
+  ["=\"New project\"", "=\"新项目\""],
+  ["placeholder:\"Search projects\"", "placeholder:\"搜索项目\""],
+  ["placeholder:\"Search projects...\"", "placeholder:\"搜索项目\""],
+  ["placeholder:\"Search projects…\"", "placeholder:\"搜索项目\""],
+  ["\"aria-label\":\"Search projects\"", "\"aria-label\":\"搜索项目\""],
+  ["recent:\"Recent\"", "recent:\"最近\""],
+  ["created:\"Created\"", "created:\"已创建\""],
+  ["alphabetical:\"Alphabetical\"", "alphabetical:\"按字母顺序\""]
+]

--- a/resources/frontend-hardcoded-zh-HK.json
+++ b/resources/frontend-hardcoded-zh-HK.json
@@ -1,0 +1,13 @@
+[
+  ["title:\"Projects\"", "title:\"項目\""],
+  ["label:\"Projects\"", "label:\"項目\""],
+  ["children:\"Projects\"", "children:\"項目\""],
+  ["=\"New project\"", "=\"新項目\""],
+  ["placeholder:\"Search projects\"", "placeholder:\"搜尋項目\""],
+  ["placeholder:\"Search projects...\"", "placeholder:\"搜尋項目\""],
+  ["placeholder:\"Search projects…\"", "placeholder:\"搜尋項目\""],
+  ["\"aria-label\":\"Search projects\"", "\"aria-label\":\"搜尋項目\""],
+  ["recent:\"Recent\"", "recent:\"最近\""],
+  ["created:\"Created\"", "created:\"已建立\""],
+  ["alphabetical:\"Alphabetical\"", "alphabetical:\"按字母順序\""]
+]

--- a/resources/frontend-hardcoded-zh-TW.json
+++ b/resources/frontend-hardcoded-zh-TW.json
@@ -1,0 +1,13 @@
+[
+  ["title:\"Projects\"", "title:\"項目\""],
+  ["label:\"Projects\"", "label:\"項目\""],
+  ["children:\"Projects\"", "children:\"項目\""],
+  ["=\"New project\"", "=\"新項目\""],
+  ["placeholder:\"Search projects\"", "placeholder:\"搜尋項目\""],
+  ["placeholder:\"Search projects...\"", "placeholder:\"搜尋項目\""],
+  ["placeholder:\"Search projects…\"", "placeholder:\"搜尋項目\""],
+  ["\"aria-label\":\"Search projects\"", "\"aria-label\":\"搜尋項目\""],
+  ["recent:\"Recent\"", "recent:\"最近\""],
+  ["created:\"Created\"", "created:\"已建立\""],
+  ["alphabetical:\"Alphabetical\"", "alphabetical:\"按字母順序\""]
+]

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -308,6 +308,7 @@ function Get-LanguageResources {
     $resourcesDir = Join-Path $projectDir "resources"
     $resources = @{
         Frontend = Join-Path $resourcesDir "frontend-$Lang.json"
+        FrontendHardcoded = Join-Path $resourcesDir "frontend-hardcoded-$Lang.json"
         Desktop = Join-Path $resourcesDir "desktop-$Lang.json"
         Statsig = Join-Path $resourcesDir "statsig-$Lang.json"
     }
@@ -720,8 +721,30 @@ function Unregister-Language {
     }
 }
 
+function Get-FrontendHardcodedReplacements {
+    param([string]$Language)
+
+    $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+    $projectDir = Split-Path -Parent $scriptDir
+    $path = Join-Path $projectDir "resources\frontend-hardcoded-$Language.json"
+    Require-File $path
+
+    $items = Get-Content $path -Raw -Encoding UTF8 | ConvertFrom-Json
+    $replacements = @()
+    foreach ($item in $items) {
+        if ($item.Count -ne 2) {
+            throw "无效的前端硬编码替换项: $path"
+        }
+        $replacements += ,@([string]$item[0], [string]$item[1])
+    }
+    return $replacements
+}
+
 function Patch-HardcodedFrontendStrings {
-    param([string]$ResourcesPath)
+    param(
+        [string]$ResourcesPath,
+        [string]$Language
+    )
 
     $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
     $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
@@ -968,6 +991,7 @@ function Patch-HardcodedFrontendStrings {
         @("`"What’s up next?`"", '"接下来做什么？"'),
         @('"Let''s knock something off your list"', '"先把清单上的一件事做完"')
     )
+    $replacements += Get-FrontendHardcodedReplacements $Language
 
     $patchedFiles = 0
     $patchedStrings = 0
@@ -1242,7 +1266,7 @@ function Install-WindowsLanguagePack {
     Register-Language $resourcesPath $LanguageCode
 
     Write-Step "[6/8] 汉化硬编码界面文本"
-    Patch-HardcodedFrontendStrings $resourcesPath
+    Patch-HardcodedFrontendStrings $resourcesPath $LanguageCode
     Patch-LanguageDisplayNames $resourcesPath
     Patch-HardcodedMainProcessMenuLabels $resourcesPath
 

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -55,6 +55,7 @@ def get_language_config(lang_code: str) -> dict[str, Any]:
     return {
         "lang_code": lang_code,
         "frontend_translation": RESOURCES / f"frontend-{lang_code}.json",
+        "frontend_hardcoded": RESOURCES / f"frontend-hardcoded-{lang_code}.json",
         "desktop_translation": RESOURCES / f"desktop-{lang_code}.json",
         "localizable_strings": RESOURCES / f"Localizable-{lang_code}.strings" if (RESOURCES / f"Localizable-{lang_code}.strings").exists() else RESOURCES / "Localizable.strings",
         "statsig_translation": RESOURCES / f"statsig-{lang_code}.json",
@@ -172,7 +173,27 @@ def patch_language_display_names(app: Path) -> None:
         print(f"Patched language display names: {path.name}")
 
 
-def patch_hardcoded_frontend_strings(app: Path) -> None:
+def load_frontend_hardcoded_replacements(lang_code: str) -> list[tuple[str, str]]:
+    path = get_language_config(lang_code)["frontend_hardcoded"]
+    require_file(path)
+    data = load_json(path)
+    if not isinstance(data, list):
+        raise SystemExit(f"Unsupported hardcoded frontend replacement JSON shape: {path}")
+
+    replacements: list[tuple[str, str]] = []
+    for item in data:
+        if not (
+            isinstance(item, list)
+            and len(item) == 2
+            and isinstance(item[0], str)
+            and isinstance(item[1], str)
+        ):
+            raise SystemExit(f"Invalid hardcoded frontend replacement entry in {path}: {item!r}")
+        replacements.append((item[0], item[1]))
+    return replacements
+
+
+def patch_hardcoded_frontend_strings(app: Path, lang_code: str) -> None:
     assets_dir = app / FRONTEND_ASSETS_REL
     replacements = {
         '"New task"': '"新建任务"',
@@ -413,6 +434,7 @@ def patch_hardcoded_frontend_strings(app: Path) -> None:
         '"aria-label":"Expand sidebar"': '"aria-label":"展开侧边栏"',
         '"aria-label":"Search"': '"aria-label":"搜索"',
     }
+    replacement_items = list(replacements.items()) + load_frontend_hardcoded_replacements(lang_code)
     patched_files = 0
     patched_strings = 0
 
@@ -420,7 +442,7 @@ def patch_hardcoded_frontend_strings(app: Path) -> None:
         text = path.read_text(encoding="utf-8")
         patched = text
         count = 0
-        for source, target in replacements.items():
+        for source, target in replacement_items:
             occurrences = patched.count(source)
             if occurrences:
                 patched = patched.replace(source, target)
@@ -942,6 +964,7 @@ def main() -> int:
     label = config["label"]
 
     require_file(config["frontend_translation"])
+    require_file(config["frontend_hardcoded"])
     require_file(config["desktop_translation"])
     require_file(config["localizable_strings"])
     if not args.app.exists():
@@ -957,7 +980,7 @@ def main() -> int:
 
     copy_app(args.app, patched_app)
     patch_language_whitelist(patched_app, lang_code)
-    patch_hardcoded_frontend_strings(patched_app)
+    patch_hardcoded_frontend_strings(patched_app, lang_code)
     patch_language_display_names(patched_app)
     patch_hardcoded_main_process_menu_labels(patched_app)
     patch_custom3p_model_validation(patched_app)


### PR DESCRIPTION
## Summary

- Adds shared hardcoded frontend replacement resources for zh-CN, zh-TW, and zh-HK.
- Updates macOS and Windows patchers to load those shared replacements when patching frontend bundles.
- Covers Projects page labels and search/sort text that can appear outside normal i18n JSON.

## Validation

- `python3 -m json.tool` for all new hardcoded replacement JSON files
- `python3 -m py_compile scripts/patch_claude_zh_cn.py`
- `git diff --check --cached` before commit
- Fixture replacement test for Projects/New project/Search projects/Recent/Created/Alphabetical
- macOS `--dry-run --lang zh-CN` completed successfully before commit

Note: PowerShell parser validation was skipped locally because `pwsh` is not installed.
