### PR TITLE
fix: 支持非打包安装的 Claude Desktop 路径检测

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -85,6 +85,27 @@ function Find-ClaudePath {
 }
 
 function Get-ClaudeResourcesPath {
+    # 优先查找非打包安装（通常版本更新）
+    $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+    if ($localAppData) {
+        $unpackagedBase = Join-Path $localAppData "AnthropicClaude"
+        if (Test-Path $unpackagedBase) {
+            $latest = Get-ChildItem $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            if ($latest) {
+                $resourcesPath = Join-Path $latest.FullName "resources"
+                if (Test-Path $resourcesPath) {
+                    return @{
+                        App = $latest.FullName
+                        Resources = $resourcesPath
+                    }
+                }
+            }
+        }
+    }
+
+    # 回退到 AppX 查找
     $claudePath = Find-ClaudePath
     if (-not $claudePath) {
         throw "未找到 Claude Desktop 安装。"
@@ -1327,6 +1348,8 @@ function Restart-Claude {
     Stop-ClaudeProcesses
 
     $exeCandidates = @(
+        (Join-Path $ClaudePath "Claude.exe"),
+        (Join-Path $ClaudePath "claude.exe"),
         (Join-Path $ClaudePath "app\Claude.exe"),
         (Join-Path $ClaudePath "app\claude.exe")
     )


### PR DESCRIPTION
## 问题

当系统同时存在 AppX 安装和非打包安装时，脚本会找到旧版 AppX 并因 bundle 代码模式不匹配而报错：

```
[8/9] 修复第三方模型名校验
Could not patch custom 3P model validation. Claude bundle format may have changed.
```

**根本原因**：`Find-ClaudePath` 只检测 AppX（Microsoft Store）安装（`Get-AppxPackage` 和 `C:\Program Files\WindowsApps\Claude_*`），不支持 `%LOCALAPPDATA%\AnthropicClaude\app-*` 下的非打包安装。

详见 [#29](https://github.com/javaht/claude-desktop-zh-cn/issues/29)

## 修复内容

### 1. `Get-ClaudeResourcesPath` — 优先检测非打包安装

在原有 AppX 查找逻辑之前，增加对 `%LOCALAPPDATA%\AnthropicClaude\app-*` 路径的检测。非打包版本通常更新，优先使用。

目录结构差异：
- **AppX**: `root\app\resources\app.asar`，exe 在 `root\app\Claude.exe`
- **非打包**: `root\resources\app.asar`，exe 在 `root\Claude.exe`

### 2. `Restart-Claude` — 兼容非打包安装的 exe 路径

在候选 exe 路径中增加根目录下的 `Claude.exe` / `claude.exe`，因为非打包版本的 exe 不在 `app\` 子目录中。

## 测试

已验证路径解析正确：
```
Resources: C:\Users\...\AppData\Local\AnthropicClaude\app-1.7196.1\resources ✅
App:       C:\Users\...\AppData\Local\AnthropicClaude\app-1.7196.1         ✅
Claude.exe: C:\Users\...\AppData\Local\AnthropicClaude\app-1.7196.1\Claude.exe ✅
```

Fixes #29