### PR TITLE
fix: 修复 Claude Desktop v1.8089 安装崩溃 + 新增安全模式

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -530,6 +530,19 @@ function Find-Custom3PValidationToggle {
     return $null
 }
 
+function Test-Custom3PValidationRemoved {
+    param([byte[]]$Content)
+
+    $contentText = [System.Text.Encoding]::ASCII.GetString($Content)
+    if (
+        (-not $contentText.Contains('expected a gateway model route referencing an Anthropic model')) -and
+        (-not $contentText.Contains('Bedrock model'))
+    ) {
+        return $true
+    }
+    return $false
+}
+
 function Find-Custom3PNameValidator {
     param(
         [byte[]]$Content,
@@ -884,6 +897,10 @@ function Patch-Custom3PModelValidation {
             return
         }
         if (-not (Patch-Custom3PNameValidator $content)) {
+            if (Test-Custom3PValidationRemoved $content) {
+                Write-Host "  custom 3P model-name validation not present (removed in this Claude version)" -ForegroundColor Green
+                return
+            }
             throw "Could not patch custom 3P model validation. Claude bundle format may have changed."
         }
     }

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,5 +1,6 @@
 ﻿param(
     [switch]$Interactive,
+    [switch]$SkipAsarPatch,
 
     [Parameter(Position = 0)]
     [ValidateSet("install", "uninstall")]
@@ -25,19 +26,21 @@ function Read-InteractiveSelection {
     Write-Host "[1] 安装简体中文"
     Write-Host "[2] 安装繁体中文（中国台湾）"
     Write-Host "[3] 安装繁体中文（中国香港）"
-    Write-Host "[4] 恢复原样 / 卸载补丁"
+    Write-Host "[4] 安装简体中文（安全模式，跳过 app.asar 补丁）"
+    Write-Host "[5] 恢复原样 / 卸载补丁"
     Write-Host "[Q] 退出"
     Write-Host ""
 
     while ($true) {
-        $selection = (Read-Host "请选择操作 [1/2/3/4/Q]").Trim()
+        $selection = (Read-Host "请选择操作 [1/2/3/4/5/Q]").Trim()
         switch -Regex ($selection) {
-            '^[1]$' { return @{ Action = "install"; Language = "zh-CN" } }
-            '^[2]$' { return @{ Action = "install"; Language = "zh-TW" } }
-            '^[3]$' { return @{ Action = "install"; Language = "zh-HK" } }
-            '^[4]$' { return @{ Action = "uninstall"; Language = "zh-CN" } }
+            '^[1]$' { return @{ Action = "install"; Language = "zh-CN"; SkipAsarPatch = $false } }
+            '^[2]$' { return @{ Action = "install"; Language = "zh-TW"; SkipAsarPatch = $false } }
+            '^[3]$' { return @{ Action = "install"; Language = "zh-HK"; SkipAsarPatch = $false } }
+            '^[4]$' { return @{ Action = "install"; Language = "zh-CN"; SkipAsarPatch = $true } }
+            '^[5]$' { return @{ Action = "uninstall"; Language = "zh-CN"; SkipAsarPatch = $false } }
             '^[Qq]$' { exit 0 }
-            default { Write-Host "请输入 1、2、3、4 或 Q。" -ForegroundColor Yellow }
+            default { Write-Host "请输入 1、2、3、4、5 或 Q。" -ForegroundColor Yellow }
         }
     }
 }
@@ -46,6 +49,9 @@ if ($Interactive) {
     $interactiveSelection = Read-InteractiveSelection
     $Action = $interactiveSelection.Action
     $Language = $interactiveSelection.Language
+    if ($interactiveSelection.SkipAsarPatch) {
+        $SkipAsarPatch = $true
+    }
 }
 
 $LanguageCode = $Language
@@ -1182,10 +1188,22 @@ function Install-WindowsLanguagePack {
     Write-Step "[7/9] 汉化硬编码界面文本"
     Patch-HardcodedFrontendStrings $resourcesPath $LanguageCode
     Patch-LanguageDisplayNames $resourcesPath
-    Patch-HardcodedMainProcessMenuLabels $resourcesPath $LanguageCode
+    if ($SkipAsarPatch) {
+        Write-Host "  skipping main-process menu label patch (app.asar) due to -SkipAsarPatch" -ForegroundColor DarkYellow
+    } else {
+        Patch-HardcodedMainProcessMenuLabels $resourcesPath $LanguageCode
+    }
 
     Write-Step "[8/9] 修复第三方模型名校验"
-    Patch-Custom3PModelValidation $resourcesPath
+    if ($SkipAsarPatch) {
+        Write-Host "  skipping 3P model validation patch (app.asar) due to -SkipAsarPatch" -ForegroundColor DarkYellow
+    } else {
+        Patch-Custom3PModelValidation $resourcesPath
+    }
+
+    if ($SkipAsarPatch) {
+        Write-Host "  skipping Claude.exe asar integrity sync due to -SkipAsarPatch" -ForegroundColor DarkYellow
+    }
 
     Write-Step "[9/9] 写入用户语言配置"
     Set-ClaudeLocale $LanguageCode

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -790,6 +790,7 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Prepare and verify a patched temp app, but do not replace /Applications/Claude.app")
     parser.add_argument("--launch", action="store_true", help="Launch Claude after installation")
     parser.add_argument("--restore", action="store_true", help="Restore the oldest macOS app backup and delete other backups")
+    parser.add_argument("--skip-asar-patch", action="store_true", help="Skip app.asar and binary integrity patches (safe mode)")
     args = parser.parse_args()
 
     try:
@@ -841,8 +842,14 @@ def main() -> int:
     patch_language_whitelist(patched_app, lang_code)
     patch_hardcoded_frontend_strings(patched_app, lang_code)
     patch_language_display_names(patched_app)
-    patch_hardcoded_main_process_menu_labels(patched_app, lang_code)
-    patch_custom3p_model_validation(patched_app)
+    if args.skip_asar_patch:
+        print("Skipping main-process menu label patch (--skip-asar-patch)")
+    else:
+        patch_hardcoded_main_process_menu_labels(patched_app, lang_code)
+    if args.skip_asar_patch:
+        print("Skipping 3P model validation patch (--skip-asar-patch)")
+    else:
+        patch_custom3p_model_validation(patched_app)
     merge_frontend_locale(patched_app, lang_code)
     install_desktop_locale(patched_app, lang_code)
     install_statsig_locale(patched_app, lang_code)

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -290,6 +290,13 @@ def calculate_file_integrity(data: bytes) -> dict[str, Any]:
     }
 
 
+def _custom3p_validation_removed(content: bytes) -> bool:
+    return (
+        b"expected a gateway model route referencing an Anthropic model" not in content
+        and b"Bedrock model" not in content
+    )
+
+
 def find_custom3p_validation_toggle(content: bytes, expr: bytes) -> re.Match[bytes] | None:
     pattern = re.compile(
         rb"const ([A-Za-z_$][A-Za-z0-9_$]*)="
@@ -401,6 +408,9 @@ def patch_custom3p_model_validation(app: Path) -> None:
             return
         patched_content = patch_custom3p_name_validator(content)
         if patched_content is None:
+            if _custom3p_validation_removed(content):
+                print("Custom 3P model-name validation not present (removed in this Claude version)")
+                return
             raise SystemExit(
                 "Could not patch custom 3P model validation. Claude bundle format may have changed."
             )


### PR DESCRIPTION
## 问题

Fixes #35
Fixes #37

两个问题：

1. **#35**：Claude Desktop v1.5354 移除了旧的 3P 模型名校验逻辑，步骤 [8/9] 抛出致命错误导致安装中断
2. **#37**：Claude Desktop v1.8089 的 Cowork 工作区在 `app.asar` 或 `Claude.exe` 被修改后报 "RPC pipe closed"，工作区无法启动

## 修改内容

### 1. 检测 3P 校验逻辑是否已被移除（修复 #35）

**`scripts/install_windows.ps1`** 新增 `Test-Custom3PValidationRemoved` 函数
**`scripts/patch_claude_zh_cn.py`** 新增 `_custom3p_validation_removed` 函数

在模型名校验器补丁失败后，检查 bundle 中是否还存在旧版校验锚点字符串。如果已不存在，说明该版本已移除此功能，跳过并输出提示信息，而非抛出致命错误。

### 2. 新增安全模式 `-SkipAsarPatch`（修复 #37）

**Windows (`install_windows.ps1`)**：
- 新增 `-SkipAsarPatch` 开关参数
- 交互式菜单新增选项 `[4] 安装简体中文（安全模式，跳过 app.asar 补丁）`
- 安全模式下跳过：主进程菜单标签补丁（app.asar）、3P 模型名校验补丁（app.asar）、Claude.exe asar 完整性哈希更新

**macOS (`patch_claude_zh_cn.py`)**：
- 新增 `--skip-asar-patch` 命令行参数
- 安全模式下跳过：主进程菜单标签补丁和 3P 模型名校验补丁

### 安全模式仍包含的汉化功能

- 语言资源文件安装（zh-CN.json 等）
- 语言白名单注册
- 前端硬编码字符串汉化（300+ 处替换）
- 语言显示名称补丁
- 用户语言配置写入

## 使用方式

```powershell
# Windows 安全模式
powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\install_windows.ps1 install zh-CN -SkipAsarPatch

# macOS 安全模式
sudo /usr/bin/python3 scripts/patch_claude_zh_cn.py --user-home "$HOME" --lang zh-CN --skip-asar-patch --launch
```

## 测试

在 Claude Desktop v1.8089.1 (Windows) 上测试：
- 完整安装（不含 -SkipAsarPatch）→ 步骤全部成功但工作区报 "RPC pipe closed" ❌
- 安全模式安装（含 -SkipAsarPatch）→ 9 步全部成功，工作区正常，中文界面生效 ✅
- 安全模式卸载 → 正常恢复 ✅
