### PR TITLE
修复 Transcript view 的中文翻译

### DIFF
--- a/resources/frontend-zh-CN.json
+++ b/resources/frontend-zh-CN.json
@@ -12853,7 +12853,7 @@
   "sERYPGnLQh": "Claude 将打开一个 Claude Code 会话，并将此任务作为第一条消息。",
   "sEcfVaSh1G": "Connect GitHub in Settings or run gh auth login",
   "sEdM03gypY": "导出所有结果",
-  "sFXw3+Ca5d": "成绩单视图",
+  "sFXw3+Ca5d": "文稿视图",
   "sFbp0HrPGn": "found {n, plural, one {# model} other {# models}}; {m} of yours not in the list",
   "sFivL9+zFU": "{count, plural, one {# 席位升级请求} other {# 个席位升级请求}}",
   "sFviXjlsqB": "所有站点的默认值",

--- a/resources/frontend-zh-HK.json
+++ b/resources/frontend-zh-HK.json
@@ -12853,7 +12853,7 @@
   "sERYPGnLQh": "Claude 將打開一個 Claude Code 會話，並將此任務作為第一條消息。",
   "sEcfVaSh1G": "Connect GitHub in Settings or run gh auth login",
   "sEdM03gypY": "導出所有結果",
-  "sFXw3+Ca5d": "成績單視圖",
+  "sFXw3+Ca5d": "文稿視圖",
   "sFbp0HrPGn": "found {n, plural, one {# model} other {# models}}; {m} of yours not in the list",
   "sFivL9+zFU": "{count, plural, one {# 席位升級請求} other {# 個席位升級請求}}",
   "sFviXjlsqB": "所有站點的默認值",

--- a/resources/frontend-zh-TW.json
+++ b/resources/frontend-zh-TW.json
@@ -12853,7 +12853,7 @@
   "sERYPGnLQh": "Claude 將打開一個 Claude Code 會話，並將此任務作為第一條消息。",
   "sEcfVaSh1G": "Connect GitHub in Settings or run gh auth login",
   "sEdM03gypY": "導出所有結果",
-  "sFXw3+Ca5d": "成績單視圖",
+  "sFXw3+Ca5d": "文稿視圖",
   "sFbp0HrPGn": "found {n, plural, one {# model} other {# models}}; {m} of yours not in the list",
   "sFivL9+zFU": "{count, plural, one {# 席位升級請求} other {# 個席位升級請求}}",
   "sFviXjlsqB": "所有站點的默認值",


### PR DESCRIPTION
修复 Transcript view`的中文翻译

此前将 `Transcript view` 译为“成绩单视图/成績單視圖”，容易误解为成绩单。根据产品语境，`Transcript` 更接近“文稿/转录文本”，因此将简体中文改为“文稿视图”，繁体中文改为“文稿視圖”。

变更文件：
- `resources/frontend-zh-CN.json`
- `resources/frontend-zh-HK.json`
- `resources/frontend-zh-TW.json`

已校验相关 JSON 文件格式正常。