### PR TITLE
fix: exclude contenteditable elements from DOM text replacement

### DIFF
--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -531,7 +531,7 @@ def build_online_dom_translation_script(lang_code: str, mapping: dict[str, str])
         "try{"
         "const b=document.body||document.documentElement;if(!b)return;"
         "const w=document.createTreeWalker(b,NodeFilter.SHOW_TEXT,{acceptNode(n){"
-        "const p=n.parentElement;if(!p||X.has(p.tagName)||!R(n.nodeValue))return NodeFilter.FILTER_REJECT;"
+        "const p=n.parentElement;if(!p||X.has(p.tagName)||p.closest('[contenteditable]')||!R(n.nodeValue))return NodeFilter.FILTER_REJECT;"
         "return NodeFilter.FILTER_ACCEPT}});"
         "let n;while(n=w.nextNode()){const v=R(n.nodeValue);if(v)n.nodeValue=v}"
         'document.querySelectorAll("[aria-label],[title],[placeholder],input,textarea").forEach(e=>{'


### PR DESCRIPTION
## 问题

在聊天输入框（空白时）输入 "App" 会被自动替换为 "应用"，
输入 "App.vue" 会变成 "应用.vue"。只在 Claude Desktop 内发生，
其他 app 正常，且只有输入框开头出现匹配词时才触发。

## 根本原因

`build_online_dom_translation_script` 注入的 MutationObserver 监听了
`characterData`（用户击键），TreeWalker 会遍历所有文本节点——包括
`contenteditable` div（聊天输入框）里的内容。当输入的文字恰好命中
翻译表中的某个 key，就会被实时替换成中文，污染用户实际发送的内容。

## 修复

在 TreeWalker 的 `acceptNode` 过滤器中增加 `p.closest('[contenteditable]')` 检查，
使所有位于可编辑区域内的文本节点直接跳过翻译替换，其余 UI 区域不受影响。

## 验证

1. 重装补丁后，在空输入框输入 "App"、"App.vue"、"Google"——不再被替换。
2. 菜单、按钮、侧边栏等 UI 中文汉化仍然正常显示。