### PR TITLE
fix: search all JS bundles for language list (fixes Claude v1.11187.1)

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1164,9 +1164,9 @@ function Register-Language {
     )
 
     $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "index-*.js") -ErrorAction SilentlyContinue)
+    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
     if ($jsFiles.Count -eq 0) {
-        throw "未找到前端 index-*.js: $assetsDir"
+        throw "未找到前端 JS bundle: $assetsDir"
     }
 
     $regex = [System.Text.RegularExpressions.Regex]::new($LanguageListPattern)
@@ -1199,9 +1199,9 @@ function Patch-LanguageDisplayNames {
     param([string]$ResourcesPath)
 
     $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "index-*.js") -ErrorAction SilentlyContinue)
+    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
     if ($jsFiles.Count -eq 0) {
-        throw "未找到前端 index-*.js: $assetsDir"
+        throw "未找到前端 JS bundle: $assetsDir"
     }
 
     $marker = "__claudeZhLabelPatch"
@@ -1229,7 +1229,7 @@ function Unregister-Language {
     param([string]$ResourcesPath)
 
     $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "index-*.js") -ErrorAction SilentlyContinue)
+    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
     foreach ($file in $jsFiles) {
         $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
         $updated = $text


### PR DESCRIPTION
## Summary

- In Claude Desktop v1.11187.1, the language whitelist array `["en-US","de-DE","fr-FR","ko-KR","ja-JP","es-419","es-ES","it-IT","hi-IN","pt-BR","id-ID"]` moved from `index-*.js` to a chunk file (`c34d1f91f-SKdatVZY.js`).
- The installer only searched `index-*.js` files in `Register-Language`, `Patch-LanguageDisplayNames`, and `Unregister-Language`, causing step 6/9 to fail with: `未能注册中文语言，Claude 前端 bundle 格式可能已经变化。`

## Fix

Change the glob pattern from `"index-*.js"` to `"*.js"` in all three functions so the language list is found regardless of which bundle file contains it.

This is backward-compatible — the regex patterns used to match/replace the language list are specific enough to avoid false positives in unrelated JS files.

## Test plan

- [ ] Run the installer with Claude Desktop v1.11187.1 and verify it completes all 9 steps successfully
- [ ] Verify the language whitelist is correctly patched in the chunk file
- [ ] Verify uninstall still works (Unregister-Language)

🤖 Generated with [Claude Code](https://claude.com/claude-code)