### PR TITLE
fix: prevent install script from killing Claude Code CLI processes

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -2333,10 +2333,23 @@ function Remove-LanguageFiles {
 }
 
 function Stop-ClaudeProcesses {
-    Stop-Process -Name "Claude" -Force -ErrorAction SilentlyContinue
-    Stop-Process -Name "claude" -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Seconds 2
-    Write-Host "  stopped Claude Desktop if it was running" -ForegroundColor Green
+    $killed = $false
+    foreach ($proc in Get-Process -Name "claude" -ErrorAction SilentlyContinue) {
+        try {
+            $path = $proc.MainModule.FileName
+            if ($path -and $path -match "WindowsApps\\Claude_") {
+                Write-Host "  正在停止 Claude Desktop (PID $($proc.Id)): $path" -ForegroundColor DarkGray
+                Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+                $killed = $true
+            }
+        } catch {
+            # MainModule inaccessible (permission or 32/64 mismatch) — skip, do NOT kill
+        }
+    }
+    if ($killed) {
+        Start-Sleep -Seconds 2
+        Write-Host "  已停止 Claude Desktop" -ForegroundColor Green
+    }
 }
 
 function Restart-Claude {


### PR DESCRIPTION
## 问题

Stop-ClaudeProcesses 函数之前会杀掉所有 claude.exe 进程，包括 Claude Code CLI。

## 修复

- 只匹配路径包含 WindowsApps\Claude_ 的进程（仅 Claude Desktop）
- 跳过无法访问 MainModule 的进程（权限或 32/64 位不匹配）
- 本地化控制台输出为中文

## 测试

- [ ] 运行安装脚本，确认不会误杀 Claude Code CLI
- [ ] 确认 Claude Desktop 进程仍能正常停止