### PR TITLE
适配 Claude Desktop 1.14271 高级文件分析文案

### DIFF
--- a/resources/frontend-zh-CN.json
+++ b/resources/frontend-zh-CN.json
@@ -3235,6 +3235,8 @@
   "C7GMZVjSu3": "对于偶尔出现的尖峰",
   "C7Sx4g/l21": "为你的内容命名",
   "C7tuVUr220": "同步正在进行中。完成后页面将自动更新。",
+  "ChatAdvancedFileAnalysisEnabled": "高级文件分析",
+  "ChatAdvancedFileAnalysisEnabledHint": "允许 Claude 在本地沙箱中运行代码，以分析它无法原生读取的附件文件（例如 Excel 和 PowerPoint），并执行内联数据分析。沙箱只能读取附加到对话的文件，且无法访问网络。默认关闭。",
   "ChatCodeExecEnabled": "允许在聊天中执行代码",
   "ChatCodeExecEnabledHint": "允许 Claude 在聊天对话的本地沙箱中运行代码。沙箱只能读取附加到对话的文件，且无法访问网络。默认关闭；关闭时，Claude 无法分析需要在聊天中进行计算的电子表格或其他文件。",
   "C81/uGekIK": "注销",

--- a/resources/frontend-zh-HK.json
+++ b/resources/frontend-zh-HK.json
@@ -3235,6 +3235,8 @@
   "C7GMZVjSu3": "對於偶爾出現的尖峯",
   "C7Sx4g/l21": "為你的內容命名",
   "C7tuVUr220": "同步正在進行中。完成後頁面將自動更新。",
+  "ChatAdvancedFileAnalysisEnabled": "進階檔案分析",
+  "ChatAdvancedFileAnalysisEnabledHint": "允許 Claude 在本機沙盒中執行程式碼，以分析它無法原生讀取的附件檔案（例如 Excel 和 PowerPoint），並執行內嵌資料分析。沙盒只能讀取附加到對話的檔案，且無法存取網絡。預設關閉。",
   "ChatCodeExecEnabled": "允許在聊天中執行程式碼",
   "ChatCodeExecEnabledHint": "允許 Claude 在聊天對話的本機沙盒中執行程式碼。沙盒只能讀取附加到對話的檔案，且無法存取網絡。預設關閉；關閉時，Claude 無法分析需要在聊天中進行計算的試算表或其他檔案。",
   "C81/uGekIK": "註銷",

--- a/resources/frontend-zh-TW.json
+++ b/resources/frontend-zh-TW.json
@@ -3235,6 +3235,8 @@
   "C7GMZVjSu3": "對於偶爾出現的尖峰",
   "C7Sx4g/l21": "為你的內容命名",
   "C7tuVUr220": "同步正在進行中。完成後頁面將自動更新。",
+  "ChatAdvancedFileAnalysisEnabled": "進階檔案分析",
+  "ChatAdvancedFileAnalysisEnabledHint": "允許 Claude 在本機沙箱中執行程式碼，以分析它無法原生讀取的附件檔案（例如 Excel 和 PowerPoint），並執行內嵌資料分析。沙箱只能讀取附加到對話的檔案，且無法存取網路。預設關閉。",
   "ChatCodeExecEnabled": "允許在聊天中執行程式碼",
   "ChatCodeExecEnabledHint": "允許 Claude 在聊天對話的本機沙箱中執行程式碼。沙箱只能讀取附加到對話的檔案，且無法存取網路。預設關閉；關閉時，Claude 無法分析需要在聊天中進行計算的試算表或其他檔案。",
   "C81/uGekIK": "註銷",


### PR DESCRIPTION
## 变更内容

- 补充 Claude Desktop 1.14271.0 新增的聊天限制设置文案：
  - `ChatAdvancedFileAnalysisEnabled`
  - `ChatAdvancedFileAnalysisEnabledHint`
- 修复设置页“Advanced file analysis”及其说明在中文语言下回退英文的问题。
- 同步更新 `zh-CN`、`zh-TW`、`zh-HK` 三份前端资源。

## 验证

- 已用本机 Claude Desktop `1.14271.0.0` 的 `ion-dist/i18n/en-US.json` 核对上述 key 均存在。
- 已验证三份 JSON 可正常解析。
- 已执行 `git diff --check`，未发现空白问题。