### PR TITLE
Add Windows patch doctor and robust app selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,15 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
    - `3` 恢复原样 / 卸载补丁
    - `4` 自动更新设置（`y` 禁止自动更新，`n` 允许自动更新）
    - `5` 同步 CC Switch skills（`y` 开启同步，`n` 删除同步）
-5. 选择安装中文补丁时，脚本会先尝试从旧备份恢复来清理已有汉化；如果没有旧备份，会提示跳过并继续。
-6. 安装时再选择语言：
+   - `6` 检查中文补丁状态
+5. 选择检查中文补丁状态时，脚本只会读取当前 Claude Desktop 版本、中文资源文件、语言白名单和用户语言配置，不会修改文件；也可以直接运行 `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install_windows.ps1 doctor zh-CN`。
+6. 选择安装中文补丁时，脚本会先尝试从旧备份恢复来清理已有汉化；如果没有旧备份，会提示跳过并继续。
+7. 安装时再选择语言：
    - `1` 简体中文
    - `2` 繁体中文（中国台湾）
    - `3` 繁体中文（中国香港）
-7. 脚本会备份当前 Claude Desktop 资源，写入本仓库 `resources` 目录里的中文 JSON，补齐硬编码界面文本，并重启 Claude Desktop。选择模式 1 时会跳过 `app.asar` 补丁，更适合需要 Cowork/截图工作区的场景。选择模式 2 时会直接修改当前 Claude 的 `app.asar`，卸载时从备份恢复。
-8. 如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
+8. 脚本会备份当前 Claude Desktop 资源，写入本仓库 `resources` 目录里的中文 JSON，补齐硬编码界面文本，并重启 Claude Desktop。选择模式 1 时会跳过 `app.asar` 补丁，更适合需要 Cowork/截图工作区的场景。选择模式 2 时会直接修改当前 Claude 的 `app.asar`，卸载时从备份恢复。
+9. 如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
 
 
 ## 文件说明
@@ -125,6 +127,7 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
 - 写入 Windows 用户配置，将语言设置为所选语言代码（`zh-CN`、`zh-TW` 或 `zh-HK`）。
 - 可选菜单项 `4` 用 `y/n` 控制 Claude Desktop 自动更新：`y` 禁止自动更新，`n` 允许自动更新。若当前存在有效的 Claude-3p `configLibrary`，脚本会写入当前 applied 配置；否则写入 `HKCU\SOFTWARE\Policies\Claude` policy。
 - 可选菜单项 `5` 用 `y/n` 控制 CC Switch skills 同步：`y` 会把 `%USERPROFILE%\.cc-switch\skills` 中缺失的 skill 以软链接加入 Claude Desktop 的本地 skills 目录，并把 `SKILL.md` frontmatter 里的 `name` 和 `description` 写入对应 `manifest.json`；`n` 只删除之前同步产生、且指向 CC Switch skills 目录内的软链接和对应 manifest 记录。脚本会从当前用户的 AppData 动态扫描 Claude-3p skills plugin，不写死 session UUID，不覆盖同名 skill，也不删除 CC Switch 源目录。
+- 可选菜单项 `6` 会检查当前 Claude Desktop 版本是否已经安装对应中文资源、前端语言白名单是否包含所选中文变体，以及用户配置中的 `locale` 是否匹配；该检查只读，不会修改文件。
 - 重启 Claude Desktop。
 
 ## 卸载 / 恢复

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -5,7 +5,7 @@
     [string]$PatchMode = "safe",
 
     [Parameter(Position = 0)]
-    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills")]
+    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills", "doctor")]
     [string]$Action = "install",
 
     [Parameter(Position = 1)]
@@ -129,14 +129,16 @@ function Read-InteractiveSelection {
     Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：（Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
+    Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
+    Write-Host "[6] 检查中文补丁状态"
     Write-Host "[Q] 退出"
     Write-Host ""
 
     $patchModeForInstall = "safe"
     $actionSelected = $false
     while (-not $actionSelected) {
-        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/Q]").Trim()
+        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/6/Q]").Trim()
         switch -Regex ($actionSelection) {
             '^[1]$' { $patchModeForInstall = "safe"; $actionSelected = $true }
             '^[2]$' { $patchModeForInstall = "official"; $actionSelected = $true }
@@ -163,8 +165,9 @@ function Read-InteractiveSelection {
                     }
                 }
             }
+            '^[6]$' { return @{ Action = "doctor"; Language = "zh-CN"; PatchMode = "safe" } }
             '^[Qq]$' { exit 0 }
-            default { Write-Host "请输入 1、2、3、4、5 或 Q。" -ForegroundColor Yellow }
+            default { Write-Host "请输入 1、2、3、4、5、6 或 Q。" -ForegroundColor Yellow }
         }
     }
 
@@ -229,6 +232,27 @@ function Format-ByteSize {
     return "$Bytes bytes"
 }
 
+function Get-UnpackagedClaudeVersion {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    if ($Directory.Name -match '^app-(\d+(?:\.\d+)*)$') {
+        try {
+            return [version]$matches[1]
+        }
+        catch {
+        }
+    }
+
+    return [version]"0.0"
+}
+
+function Test-UnpackagedClaudeAppDirectory {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    return (Test-Path -LiteralPath (Join-Path $Directory.FullName "Claude.exe")) -and
+        (Test-Path -LiteralPath (Join-Path $Directory.FullName "resources"))
+}
+
 function Get-UnpackagedClaudePaths {
     $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
     if (-not $localAppData) {
@@ -241,7 +265,8 @@ function Get-UnpackagedClaudePaths {
     }
 
     return @(Get-ChildItem $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime -Descending |
+        Where-Object { Test-UnpackagedClaudeAppDirectory $_ } |
+        Sort-Object @{ Expression = { Get-UnpackagedClaudeVersion $_ }; Descending = $true }, @{ Expression = { $_.LastWriteTime }; Descending = $true } |
         ForEach-Object { $_.FullName })
 }
 
@@ -2253,6 +2278,119 @@ function Set-ClaudeLocale {
     }
 }
 
+function Test-LanguageRegistered {
+    param(
+        [string]$ResourcesPath,
+        [string]$Lang
+    )
+
+    $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
+    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
+    if ($jsFiles.Count -eq 0) {
+        return $false
+    }
+
+    $regex = [System.Text.RegularExpressions.Regex]::new($LanguageListPattern)
+    foreach ($file in $jsFiles) {
+        $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
+        foreach ($match in $regex.Matches($text)) {
+            if ($match.Value.Contains("`"$Lang`"")) {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+function Invoke-WindowsLanguagePackDoctor {
+    param([string]$Lang)
+
+    $ok = $true
+
+    Write-Host "=== Claude Desktop Windows 中文补丁检查 ==="
+
+    Write-Step "[1/4] 查找 Claude Desktop"
+    $paths = Get-ClaudeResourcesPath
+    $resourcesPath = $paths["Resources"]
+    Write-Host "  app: $($paths["App"])" -ForegroundColor Green
+    Write-Host "  resources: $resourcesPath" -ForegroundColor Green
+
+    Write-Step "[2/4] 检查语言资源"
+    $resourceChecks = @(
+        @{ Label = "ion-dist/i18n/$Lang.json"; Path = Join-Path $resourcesPath "ion-dist\i18n\$Lang.json" },
+        @{ Label = "resources/$Lang.json"; Path = Join-Path $resourcesPath "$Lang.json" },
+        @{ Label = "ion-dist/i18n/statsig/$Lang.json"; Path = Join-Path $resourcesPath "ion-dist\i18n\statsig\$Lang.json" }
+    )
+
+    foreach ($check in $resourceChecks) {
+        if (Test-Path -LiteralPath $check.Path) {
+            Write-Host "  OK $($check.Label)" -ForegroundColor Green
+        }
+        else {
+            Write-Host "  MISSING $($check.Label)" -ForegroundColor Red
+            $ok = $false
+        }
+    }
+
+    $backupRoot = Get-BackupRoot $resourcesPath
+    if (Test-Path -LiteralPath $backupRoot) {
+        Write-Host "  backup: $backupRoot" -ForegroundColor DarkGray
+    }
+    else {
+        Write-Host "  backup not found: $backupRoot" -ForegroundColor DarkYellow
+    }
+
+    Write-Step "[3/4] 检查语言注册"
+    if (Test-LanguageRegistered $resourcesPath $Lang) {
+        Write-Host "  OK $Lang registered in frontend language whitelist" -ForegroundColor Green
+    }
+    else {
+        Write-Host "  MISSING $Lang in frontend language whitelist" -ForegroundColor Red
+        $ok = $false
+    }
+
+    Write-Step "[4/4] 检查用户语言配置"
+    $configPaths = @(Get-ClaudeConfigPaths | Select-Object -Unique)
+    if ($configPaths.Count -eq 0) {
+        Write-Host "  MISSING Claude config paths" -ForegroundColor Red
+        $ok = $false
+    }
+
+    foreach ($configPath in $configPaths) {
+        if (-not (Test-Path -LiteralPath $configPath)) {
+            Write-Host "  MISSING locale=${Lang}: $configPath" -ForegroundColor Red
+            $ok = $false
+            continue
+        }
+
+        try {
+            $config = Get-Content $configPath -Raw | ConvertFrom-Json
+            $locale = [string]$config.locale
+            if ($locale -eq $Lang) {
+                Write-Host "  OK locale=${Lang}: $configPath" -ForegroundColor Green
+            }
+            else {
+                Write-Host "  MISMATCH locale=${locale}: $configPath" -ForegroundColor Red
+                $ok = $false
+            }
+        }
+        catch {
+            Write-Host "  INVALID JSON: $configPath" -ForegroundColor Red
+            $ok = $false
+        }
+    }
+
+    Write-Host ""
+    if ($ok) {
+        Write-Host "检查完成：$Lang 补丁已安装到当前 Claude Desktop 版本。" -ForegroundColor Green
+        return $true
+    }
+
+    Write-Host "检查完成：当前 Claude Desktop 版本缺少中文补丁或用户语言配置异常，请重新运行安装。" -ForegroundColor Red
+    return $false
+}
+
 function Get-ThirdPartyConfigLibraryPaths {
     $paths = @()
     $appDataRoots = @()
@@ -3200,6 +3338,11 @@ try {
         "enable-updates" { Set-ClaudeAutoUpdates $true }
         "sync-skills" { Sync-CCSwitchSkills }
         "unsync-skills" { Unsync-CCSwitchSkills }
+        "doctor" {
+            if (-not (Invoke-WindowsLanguagePackDoctor $LanguageCode)) {
+                throw "中文补丁检查未通过。"
+            }
+        }
     }
 
     Stop-InstallLog
@@ -3213,7 +3356,7 @@ catch {
     }
     Stop-InstallLog
     if ($Interactive) {
-        [void](Read-Host "安装未完成，按 Enter 退出")
+        [void](Read-Host "操作未完成，按 Enter 退出")
     }
     exit 1
 }


### PR DESCRIPTION
## Summary
- add a Windows `doctor` action to verify the current Claude Desktop Chinese patch state without modifying files
- select unpackaged `app-*` directories by valid app contents and semantic version instead of directory `LastWriteTime`
- expose the missing auto-update menu item and document the new check mode

## Why
Claude Desktop updates can leave older `app-*` directories behind. A stale or `.dead` directory may have a newer `LastWriteTime`, causing the Windows script to pick an invalid install path. The new doctor action also gives users a quick way to distinguish an update-related missing patch from a locale/config problem.

## Verification
- Parsed `scripts/install_windows.ps1` with PowerShell parser
- Ran `powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\install_windows.ps1 doctor zh-CN`
- Ran `git diff --check`