### PR TITLE
Fix Windows unpackaged Claude app selection

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -229,6 +229,27 @@ function Format-ByteSize {
     return "$Bytes bytes"
 }
 
+function Get-UnpackagedClaudeVersion {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    if ($Directory.Name -match '^app-(\d+(?:\.\d+)*)$') {
+        try {
+            return [version]$matches[1]
+        }
+        catch {
+        }
+    }
+
+    return [version]"0.0"
+}
+
+function Test-UnpackagedClaudeAppDirectory {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    return (Test-Path -LiteralPath (Join-Path $Directory.FullName "Claude.exe")) -and
+        (Test-Path -LiteralPath (Join-Path $Directory.FullName "resources"))
+}
+
 function Get-UnpackagedClaudePaths {
     $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
     if (-not $localAppData) {
@@ -241,7 +262,8 @@ function Get-UnpackagedClaudePaths {
     }
 
     return @(Get-ChildItem $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime -Descending |
+        Where-Object { Test-UnpackagedClaudeAppDirectory $_ } |
+        Sort-Object @{ Expression = { Get-UnpackagedClaudeVersion $_ }; Descending = $true }, @{ Expression = { $_.LastWriteTime }; Descending = $true } |
         ForEach-Object { $_.FullName })
 }
 


### PR DESCRIPTION
## Summary
- filter Windows unpackaged `app-*` candidates to real Claude app directories with both `Claude.exe` and `resources`
- sort valid candidates by semantic app version first, using `LastWriteTime` only as a tie-breaker

## Why
This is split out from #101 based on maintainer feedback. The previous logic selected the newest `LastWriteTime`, which can pick a stale or `.dead` app directory left behind by Squirrel updates instead of the current valid Claude Desktop version.

## Verification
- PowerShell 5.1 AST parse for `scripts/install_windows.ps1`
- PowerShell 7 AST parse for `scripts/install_windows.ps1`
- `git diff --check`
- Local multi-`app-*` smoke confirmed invalid app directories are ignored and the highest valid version is selected