### PR TITLE
fix(windows): 补全安装菜单缺失的选项[4]并修正模式1的Cowork描述

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -126,9 +126,10 @@ Test-GitHubReleaseUpdate
 function Read-InteractiveSelection {
     Write-Host "=== Claude Desktop Windows 中文补丁 ==="
     Write-Host ""
-    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：（Cowork 沙箱/工作区不可用(看群公告))"
+    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：Cowork 兼容（跳过 app.asar 补丁，第三方模型请用网关或 ccswitch 别名映射）)"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
+    Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
     Write-Host "[Q] 退出"
     Write-Host ""


### PR DESCRIPTION
- 在交互菜单中补全选项 [4] 自动更新设置，修复菜单显示跳过 [4] 但 switch 逻辑已处理该选项的 bug
- 修正模式 1 (safe) 的 Cowork 描述：从'Cowork 沙箱/工作区不可用'改为'Cowork 兼容'，与 README 和实际行为一致（safe 模式跳过 app.asar 补丁，保留签名完整性）