### PR TITLE
feat: 新增翻译条目、多语言DOM脚本支持，修复繁体文件简体字混入

### DIFF
--- a/resources/desktop-zh-CN.json
+++ b/resources/desktop-zh-CN.json
@@ -303,6 +303,7 @@
   "qKeKrKCSD+": "MCP 配置重新加载失败",
   "qz9XeGmw0N": "取消",
   "r/37cmiGuE": "无法打开技能",
+  "r6AwevAvuz": "释放 Cowork 磁盘空间…",
   "r7yWnNBpJl": "连接",
   "rCO+ULu7rr": "扩展 {extensionId} 被安全阻止列表拦截：{reason}",
   "rNAd+HxSK4": "打开 MCP 日志文件",

--- a/resources/desktop-zh-TW.json
+++ b/resources/desktop-zh-TW.json
@@ -303,6 +303,7 @@
   "qKeKrKCSD+": "MCP 配置重新加載失敗",
   "qz9XeGmw0N": "取消",
   "r/37cmiGuE": "無法打開技能",
+  "r6AwevAvuz": "釋放 Cowork 磁碟空間…",
   "r7yWnNBpJl": "連接",
   "rCO+ULu7rr": "擴展 {extensionId} 被安全阻止列表攔截：{reason}",
   "rNAd+HxSK4": "打開 MCP 日誌文件",

--- a/resources/frontend-hardcoded-zh-HK.json
+++ b/resources/frontend-hardcoded-zh-HK.json
@@ -229,7 +229,7 @@
   ],
   [
     "Archived",
-    "已歸檔"
+    "已封存"
   ],
   [
     "All",
@@ -297,7 +297,7 @@
   ],
   [
     "[\"none\",\"None\"]",
-    "[\"none\",\"无\"]"
+    "[\"none\",\"無\"]"
   ],
   [
     "[\"project\",\"Project\"]",
@@ -305,7 +305,7 @@
   ],
   [
     "[\"state\",\"State\"]",
-    "[\"state\",\"状态\"]"
+    "[\"state\",\"状態\"]"
   ],
   [
     "]:t.title??\"Local task\"]",
@@ -369,7 +369,7 @@
   ],
   [
     "s>0&&C(`${s} ${1===s?b.noun:b.nouns} ${F?\"archived\":\"deleted\"}`)",
-    "s>0&&C(F?`${s} 個${1===s?b.noun:b.nouns}已歸檔`:`${s} ${1===s?b.noun:b.nouns} deleted`)"
+    "s>0&&C(F?`${s} 個${1===s?b.noun:b.nouns}已封存`:`${s} ${1===s?b.noun:b.nouns} deleted`)"
   ],
   [
     "n>0?g(`${n} ${1===n?b.noun:b.nouns} could not be ${F?\"archived\":\"deleted\"}. You can try again.`,{messageForLogging:\"ChatsSurface bulk delete partial failure\"})",
@@ -465,7 +465,7 @@
   ],
   [
     "hint:\"How the gateway credential is sent. Choose Bearer or x-api-key for a static key or credential-helper output; choose SSO to have each user sign in via your identity provider.\"",
-    "hint:\"閘道憑證的傳送方式。靜態密鑰或憑證輔助腳本輸出請選擇 Bearer 或 x-api-key；如需每位用户透過你的身份提供者登入，請選擇 SSO。\""
+    "hint:\"閘道憑證的傳送方式。靜態密鑰或憑證輔助腳本輸出請選擇 Bearer 或 x-api-key；如需每位用戶透過你的身份提供者登入，請選擇 SSO。\""
   ],
   [
     "hint:\"Org-pushed MCP servers — remote (HTTP/SSE) or local (stdio command). May embed bearer tokens.\"",
@@ -1001,7 +1001,7 @@
   ],
   [
     "Allow Claude to remember relevant context from your chats. This setting controls memory for both chats and projects.",
-    "允許 Claude 記住你聊天中的相關脈絡。此設定會同時控制聊天和專案的記憶。"
+    "允許 Claude 記住你聊天中的相關脈絡。此設定會同時控制聊天和項目的記憶。"
   ],
   [
     "Import memory from other AI providers",
@@ -1057,7 +1057,7 @@
   ],
   [
     "HTTPS endpoint that returns a per-user JSON config overlay. Values from the response override local settings and become read-only.",
-    "傳回每位用户 JSON 設定覆寫層的 HTTPS 端點。回應中的值會覆寫本機設定並變為唯讀。"
+    "傳回每位用戶 JSON 設定覆寫層的 HTTPS 端點。回應中的值會覆寫本機設定並變為唯讀。"
   ],
   [
     "Tasks",
@@ -1121,11 +1121,11 @@
   ],
   [
     "When enabled, users can select Auto mode (Code tab) / Act without asking (Cowork tab). Claude runs a safety classifier on each action and only prompts for approval on actions it judges risky.",
-    "啟用後，用户可以選擇自動模式（Code 分頁）/ 無需詢問即可操作（Cowork 分頁）。Claude 會對每個操作執行安全分類器，並且只在判定為有風險的操作上要求核准。"
+    "啟用後，用戶可以選擇自動模式（Code 分頁）/ 無需詢問即可操作（Cowork 分頁）。Claude 會對每個操作執行安全分類器，並且只在判定為有風險的操作上要求核准。"
   ],
   [
     "When enabled, users can select **Auto mode** (Code tab) / **Act without asking** (Cowork tab). Claude runs a safety classifier on each action and only prompts for approval on actions it judges risky.\\n\\nRequires a model that supports the classifier (Claude 4.6+). Older models show the option greyed out.\\n\\nThis is the permissive opposite of the per-tool `ask` policy above; both may be set.",
-    "啟用後，用户可以選擇 **自動模式**（Code 分頁）/ **無需詢問即可操作**（Cowork 分頁）。Claude 會對每個操作執行安全分類器，並且只在判定為有風險的操作上要求核准。\\n\\n需要支援該分類器的模型（Claude 4.6+）。較舊模型會將此選項顯示為灰色。\\n\\n這是上方按工具設定的 `ask` 策略的寬鬆反向選項；兩者可以同時設定。"
+    "啟用後，用戶可以選擇 **自動模式**（Code 分頁）/ **無需詢問即可操作**（Cowork 分頁）。Claude 會對每個操作執行安全分類器，並且只在判定為有風險的操作上要求核准。\\n\\n需要支援該分類器的模型（Claude 4.6+）。較舊模型會將此選項顯示為灰色。\\n\\n這是上方按工具設定的 `ask` 策略的寬鬆反向選項；兩者可以同時設定。"
   ],
   [
     "Requires a model that supports the classifier (Claude 4.6+). Older models show the option greyed out.",
@@ -1217,11 +1217,11 @@
   ],
   [
     "Show details",
-    "顯示詳細資訊"
+    "顯示詳細資料"
   ],
   [
     "Hide details",
-    "隱藏詳細資訊"
+    "隱藏詳細資料"
   ],
   [
     "Read docs",
@@ -1250,5 +1250,493 @@
   [
     "Speed",
     "速度"
+  ],
+  [
+    "Add header",
+    "新增請求標頭"
+  ],
+  [
+    "Application",
+    "應用程式"
+  ],
+  [
+    "Allow Claude to automatically classify sessions as blocked, ready for review, or done. Classifying sessions counts towards your plan usage. Applies to new sessions.",
+    "允許 Claude 自動將工作階段分類為已阻止、待審核或已完成。分類工作階段會計入你的計劃用量。適用於新工作階段。"
+  ],
+  [
+    "Are you sure you want to delete 1 chat? This cannot be undone.",
+    "你確定要刪除 1 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Are you sure you want to delete {count} chat? This cannot be undone.",
+    "你確定要刪除 {count} 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Are you sure you want to delete {count} chats? This cannot be undone.",
+    "你確定要刪除 {count} 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Authorization tokens",
+    "授權權杖"
+  ],
+  [
+    "Auto-archive after PR merge or close",
+    "PR 合併或關閉後自動歸檔"
+  ],
+  [
+    "Automatically archive desktop sessions when the associated pull request is merged or closed.",
+    "關聯的拉取請求合併或關閉後，自動歸檔桌面工作階段。"
+  ],
+  [
+    "Autofix pull requests",
+    "自動修復拉取請求"
+  ],
+  [
+    "Auto-populate the model picker from /v1/models at launch.",
+    "啟動時從 /v1/models 自動填入模型選擇器。"
+  ],
+  [
+    "Auto-populate the model picker from {url} at launch.",
+    "啟動時從 {url} 自動填入模型選擇器。"
+  ],
+  [
+    "Claude understands your codebase and helps you build, debug, and ship faster. Upgrade your plan to get started.",
+    "Claude 了解你的代碼庫，能幫助你更快地構建、調試和發布。升級你的計劃即可開始使用。"
+  ],
+  [
+    "Claude understands your codebase and helps you build, debug, and ship faster. Get started in the desktop app.",
+    "Claude 了解你的代碼庫，能幫助你更快地構建、調試和發布。請在桌面應用程式中開始使用。"
+  ],
+  [
+    "Claude Code (CLI, Desktop, IDE)",
+    "Claude Code（CLI、桌面版、IDE）"
+  ],
+  [
+    "Claude Light",
+    "Claude 淺色"
+  ],
+  [
+    "Claude Dark",
+    "Claude 深色"
+  ],
+  [
+    "Classify session states",
+    "分類工作階段狀態"
+  ],
+  [
+    "Created when you sign in to Claude Code. Revoke a token to sign out from that device.",
+    "登入 Claude Code 時創建。撤銷權杖即可讓該裝置退出登入。"
+  ],
+  [
+    "Choose where Claude Desktop sends inference requests.",
+    "選擇 Claude Desktop 將推理請求傳送到哪裡。"
+  ],
+  [
+    "Connection",
+    "連線"
+  ],
+  [
+    "Connectors & extensions",
+    "連接器與擴充功能"
+  ],
+  [
+    "Credential kind",
+    "憑證類型"
+  ],
+  [
+    "Custom inference headers",
+    "自訂推理請求標頭"
+  ],
+  [
+    "Default",
+    "預設"
+  ],
+  [
+    "Egress Requirements",
+    "輸出要求"
+  ],
+  [
+    "Extensions",
+    "擴充功能"
+  ],
+  [
+    "Extra HTTP headers sent on every inference request to the configured provider. For tenant routing, org IDs, Bedrock Guardrails, etc.",
+    "每次向所配置提供者傳送推理請求時附加的 HTTP 請求標頭。可用於租戶路由、組織 ID、Bedrock Guardrails 等場景。"
+  ],
+  [
+    "High-contrast dark theme",
+    "高對比度深色主題"
+  ],
+  [
+    "Use a darker, near-black background when dark mode is on.",
+    "開啟深色模式時使用更暗、接近黑色的背景。"
+  ],
+  [
+    "When you create a pull request, Claude automatically monitors it for CI failures and review comments, then responds proactively. Claude may post comments on your behalf.",
+    "創建拉取請求後，Claude 會自動監控 CI 失敗和評審評論，並主動響應。Claude 可能會代表你發表評論。"
+  ],
+  [
+    "Browse extensions",
+    "瀏覽擴充功能"
+  ],
+  [
+    "Full URL of the inference gateway endpoint.",
+    "推理閘道端點的完整 URL。"
+  ],
+  [
+    "Gateway",
+    "閘道"
+  ],
+  [
+    "Gateway base URL",
+    "閘道基礎 URL"
+  ],
+  [
+    "GATEWAY CREDENTIALS",
+    "閘道憑證"
+  ],
+  [
+    "网关 credentials",
+    "閘道憑證"
+  ],
+  [
+    "{provider} credentials",
+    "{provider} 憑證"
+  ],
+  [
+    "Learn more",
+    "了解更多"
+  ],
+  [
+    "Model list",
+    "模型清單"
+  ],
+  [
+    "Models",
+    "模型"
+  ],
+  [
+    "Models to show in the picker. First entry is the default.",
+    "顯示在模型選擇器中的模型。第一項為預設模型。"
+  ],
+  [
+    "MODELS",
+    "模型"
+  ],
+  [
+    "Override the auto-discovered model list. First entry is the default.",
+    "覆蓋自動探索的模型清單。第一項為預設模型。"
+  ],
+  [
+    "Plugins & skills",
+    "插件與技能"
+  ],
+  [
+    "Search settings",
+    "搜尋設定"
+  ],
+  [
+    "Selects the credential source. When set, only that source is used (no fallback).",
+    "選擇憑證來源。設定後只會使用該來源，不會回退。"
+  ],
+  [
+    "Telemetry & updates",
+    "診斷與更新"
+  ],
+  [
+    "Usage limits",
+    "使用限制"
+  ],
+  [
+    "Workspace restrictions",
+    "工作區限制"
+  ],
+  [
+    "Allow all",
+    "全部允許"
+  ],
+  [
+    "Allow Claude Code tab",
+    "允許 Claude Code 分頁"
+  ],
+  [
+    "Allow desktop extensions",
+    "允許桌面擴充功能"
+  ],
+  [
+    "Allow user-added MCP servers",
+    "允許使用者新增 MCP 伺服器"
+  ],
+  [
+    "Allowed egress hosts",
+    "允許的輸出主機"
+  ],
+  [
+    "Allowed workspace folders",
+    "允許的工作區資料夾"
+  ],
+  [
+    "AUTO-UPDATES",
+    "自動更新"
+  ],
+  [
+    "ANTHROPIC TELEMETRY",
+    "Anthropic 診斷資料"
+  ],
+  [
+    "Block essential telemetry",
+    "阻止必要診斷資料"
+  ],
+  [
+    "Block nonessential services",
+    "阻止非必要服務"
+  ],
+  [
+    "Block nonessential telemetry",
+    "阻止非必要診斷資料"
+  ],
+  [
+    "Built-in tool policy",
+    "內建工具政策"
+  ],
+  [
+    "Built-in tools removed from Cowork.",
+    "從 Cowork 中移除的內建工具。"
+  ],
+  [
+    "Choose from disk",
+    "從磁碟選擇"
+  ],
+  [
+    "Choose...",
+    "選擇..."
+  ],
+  [
+    ".dxt and .mcpb installs.",
+    ".dxt 和 .mcpb 安裝包。"
+  ],
+  [
+    "Copy",
+    "複製"
+  ],
+  [
+    "CORE (VM BUNDLE + CLAUDE CLI BINARY)",
+    "核心（VM 包 + Claude CLI 二進位檔案）"
+  ],
+  [
+    "DESKTOP EXTENSIONS (PYTHON RUNTIME)",
+    "桌面擴充功能（Python 執行階段）"
+  ],
+  [
+    "Disable Claude.ai sign-in",
+    "停用 Claude.ai 登入"
+  ],
+  [
+    "Disable claude:// deep-link handling",
+    "停用 claude:// 深層連結處理"
+  ],
+  [
+    "Disabled built-in tools",
+    "停用內建工具"
+  ],
+  [
+    "Domains Cowork's tools may reach during a turn. Also surfaced under Egress Requirements.",
+    "Cowork 的工具在一次任務中可以訪問的網域。也會顯示在輸出要求中。"
+  ],
+  [
+    "Domains Cowork's tools may reach during a turn. Also surfaced under 出站要求.",
+    "Cowork 的工具在一次任務中可以訪問的網域。也會顯示在輸出要求中。"
+  ],
+  [
+    "ESSENTIAL TELEMETRY",
+    "必要診斷資料"
+  ],
+  [
+    "EXTENSIONS",
+    "擴充功能"
+  ],
+  [
+    "Favicon fetch and the artifact-preview iframe origin. Artifacts will not render.",
+    "獲取網站圖示和 Artifact 預覽 iframe 來源。Artifacts 將無法渲染。"
+  ],
+  [
+    "Folders users may attach as a workspace. Leave unset for unrestricted access.",
+    "使用者可作為工作區附加的資料夾。留空則不限制。"
+  ],
+  [
+    "Hosts your network firewall must allow, derived from your current settings. This list is read-only and updates as you make changes. Traffic is HTTPS on port 443 unless a custom port is specified (OTLP, gateway, or MCP server URLs).",
+    "根據當前設定生成的網絡防火牆允許清單。此清單為唯讀，並會隨配置變更自動更新。除非指定了自訂端口（OTLP、閘道或 MCP 伺服器 URL），否則流量均為 443 端口上的 HTTPS。"
+  ],
+  [
+    "Local stdio servers added via the Developer settings. Remote servers come from the managed list above, or plugins mounted to a user's computer by an organization admin.",
+    "通過開發者設定新增的本地 stdio 伺服器。遠端伺服器來自上方託管清單，或來自組織管理員掛載到使用者電腦上的插件。"
+  ],
+  [
+    "Managed MCP servers",
+    "託管的 MCP 伺服器"
+  ],
+  [
+    "Max tokens per window",
+    "每個視窗最大權杖數"
+  ],
+  [
+    "MCP SERVERS",
+    "MCP 伺服器"
+  ],
+  [
+    "Mount plugin bundles to this folder using your device-management tool and Cowork will load them at launch. The folder is read-only; tool policies you set below are saved in this configuration.",
+    "使用裝置管理工具將插件包掛載到此資料夾，Cowork 會在啟動時載入。該資料夾為唯讀；下面設定的工具政策會保存在此配置中。"
+  ],
+  [
+    "NONESSENTIAL SERVICES",
+    "非必要服務"
+  ],
+  [
+    "NONESSENTIAL TELEMETRY",
+    "非必要診斷資料"
+  ],
+  [
+    "ORGANIZATION PLUGINS",
+    "組織插件"
+  ],
+  [
+    "Organization UUID",
+    "組織 UUID"
+  ],
+  [
+    "Org-pushed MCP servers: remote (HTTP/SSE) or local (stdio command). May embed bearer tokens.",
+    "組織推送的 MCP 伺服器：遠端（HTTP/SSE）或本地（stdio 命令）。可能嵌入 Bearer 權杖。"
+  ],
+  [
+    "Per-tool approval policy. \"ask\" requires user approval before each call; \"allow\" is the default. Use Disabled built-in tools to remove a tool entirely.",
+    "按工具設定的核准政策。\"ask\" 表示每次調用前都需要使用者核准；\"allow\" 為預設值。如需完全移除某個工具，請使用“停用內建工具”。"
+  ],
+  [
+    "Per-user soft cap, counted client-side over the duration below. Not a server-enforced quota.",
+    "按使用者設定的軟上限，會在下方時長內由客戶端統計。不是伺服器強制執行的配額。"
+  ],
+  [
+    "Product-usage analytics and diagnostic-report uploads. No message content.",
+    "產品使用分析和診斷報告上傳。不包含訊息內容。"
+  ],
+  [
+    "Prompts, completions, and your data are never sent to Anthropic. Telemetry covers crash and usage signals only.",
+    "提示、補全和你的資料絕不會傳送給 Anthropic。診斷資料只包含崩潰和使用信號。"
+  ],
+  [
+    "Reject desktop extensions that are not signed by a trusted publisher.",
+    "拒絕未由受信任發行者簽署的桌面擴充功能。"
+  ],
+  [
+    "Require signed extensions",
+    "要求擴充功能已簽署"
+  ],
+  [
+    "Show the Code tab (terminal-based coding sessions). Sessions run on the host, not inside the VM.",
+    "顯示 Code 分頁（基於終端的編碼工作階段）。工作階段在主機上執行，不在 VM 內執行。"
+  ],
+  [
+    "Tags telemetry events with your organization's UUID so Anthropic support can find them. Not used for auth.",
+    "使用你組織的 UUID 標記診斷資料事件，方便 Anthropic 支援人員定位。不會用於認證。"
+  ],
+  [
+    "tokens",
+    "權杖"
+  ],
+  [
+    "Users see only this provider at the login screen. The option to sign in to Claude.ai is hidden.",
+    "使用者在登入頁只會看到此提供者。Claude.ai 登入選項會被隱藏。"
+  ],
+  [
+    "Crash and performance reports to Anthropic.",
+    "傳送給 Anthropic 的崩潰和效能報告。"
+  ],
+  [
+    "Add server policy",
+    "新增伺服器政策"
+  ],
+  [
+    "+ Add server policy",
+    "+ 新增伺服器政策"
+  ],
+  [
+    "Add policy",
+    "新增政策"
+  ],
+  [
+    "Anthropic telemetry",
+    "Anthropic 診斷資料"
+  ],
+  [
+    "OpenTelemetry",
+    "OpenTelemetry 診斷資料"
+  ],
+  [
+    "OpenTelemetry collector endpoint",
+    "OpenTelemetry 收集器端點"
+  ],
+  [
+    "Where Cowork sends OpenTelemetry logs and metrics. Leave blank to disable.",
+    "Cowork 傳送 OpenTelemetry 日誌和指標的位置。留空則停用。"
+  ],
+  [
+    "Updates",
+    "更新"
+  ],
+  [
+    "Block auto-updates",
+    "阻止自動更新"
+  ],
+  [
+    "Stop Cowork from fetching updates. You'll need to push new versions yourself.",
+    "阻止 Cowork 獲取更新。你需要自行推送新版本。"
+  ],
+  [
+    "Auto-update enforcement window",
+    "自動更新強制時窗"
+  ],
+  [
+    "Hours before a downloaded update force-installs. Blank = 72-hour default.",
+    "已下載更新在強制安裝前等待的小時數。留空則預設為 72 小時。"
+  ],
+  [
+    "<b>{category}</b> needs {count, plural, one {{label}} other {# fields}}",
+    "<b>{category}</b> 需要 {count, plural, one {{label}} other {# 個欄位}}"
+  ],
+  [
+    "Per-tool approval policy. \"ask\" requires user approval before each call; \"allow\" is the default. Use 禁用内置工具 to remove a tool entirely.",
+    "按工具設定的核准政策。“ask” 表示每次調用前都需要使用者核准；“allow” 為預設值。如需完全移除某個工具，請使用“停用內建工具”。"
+  ],
+  [
+    "Hi! How can I help you today?",
+    "你好！今天我能為你提供什麼幫助？"
+  ],
+  [
+    "Write a message...",
+    "輸入訊息..."
+  ],
+  [
+    "Write a message…",
+    "輸入訊息..."
+  ],
+  [
+    "message:F?`归档 ${j.items.length} ${1===j.items.length?b.noun:b.nouns}？你可以在“已归档”标签页中找到${1===j.items.length?\"它\":\"它们\"}。`",
+    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在“已封存”分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+  ],
+  [
+    "CR={local:\"Local\",remote:\"Cloud\",bridge:\"Remote Control\",slack:\"Slack\"}",
+    "CR={local:\"本地\",remote:\"雲端\",bridge:\"遙距控制\",slack:\"Slack\"}"
+  ],
+  [
+    "\"Run tasks on a schedule or whenever you need them.\"",
+    "\"按排程或在需要時執行任務。\""
+  ],
+  [
+    "\"Run tasks on a schedule or whenever you need them. Type /schedule in any existing task to set one up.\"",
+    "\"按排程執行任務，或在需要時執行任務。在任意現有任務中輸入 /schedule 即可設定。\""
+  ],
+  [
+    "defaultMessage:\"All environments\",id:\"SBWkijOQlK\"",
+    "defaultMessage:\"所有環境\",id:\"SBWkijOQlK\""
   ]
 ]

--- a/resources/frontend-hardcoded-zh-TW.json
+++ b/resources/frontend-hardcoded-zh-TW.json
@@ -161,7 +161,7 @@
   ],
   [
     "\"aria-label\":\"Search projects\"",
-    "\"aria-label\":\"搜尋項目\""
+    "\"aria-label\":\"搜尋專案\""
   ],
   [
     "\"expected a Foundry deployment name referencing an Anthropic model (e.g. claude-sonnet-4-5). Name deployments to match the underlying model.\"",
@@ -177,7 +177,7 @@
   ],
   [
     "=\"New project\"",
-    "=\"新項目\""
+    "=\"新專案\""
   ],
   [
     "Ca=\"Local\"",
@@ -285,7 +285,7 @@
   ],
   [
     "[\"archived\",\"Archived\"]",
-    "[\"archived\",\"已封存\"]"
+    "[\"archived\",\"已歸檔\"]"
   ],
   [
     "[\"date\",\"Date\"]",
@@ -297,7 +297,7 @@
   ],
   [
     "[\"none\",\"None\"]",
-    "[\"none\",\"无\"]"
+    "[\"none\",\"無\"]"
   ],
   [
     "[\"project\",\"Project\"]",
@@ -305,7 +305,7 @@
   ],
   [
     "[\"state\",\"State\"]",
-    "[\"state\",\"状态\"]"
+    "[\"state\",\"状態\"]"
   ],
   [
     "]:t.title??\"Local task\"]",
@@ -349,15 +349,15 @@
   ],
   [
     "message:F?`Archive ${j.items.length} ${1===j.items.length?b.noun:b.nouns}? You can find ${1===j.items.length?\"it\":\"them\"} in the Archived tab.`",
-    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在「已封存」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在「已歸檔」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
   ],
   [
     "message:z?`Archive ${_.items.length} ${1===_.items.length?b.noun:b.nouns}? You can find ${1===_.items.length?\"it\":\"them\"} in the Archived tab.`",
-    "message:z?`歸檔 ${_.items.length} 個${1===_.items.length?b.noun:b.nouns}？你可以在「已封存」分頁中找到${1===_.items.length?\"它\":\"它們\"}。`"
+    "message:z?`歸檔 ${_.items.length} 個${1===_.items.length?b.noun:b.nouns}？你可以在「已歸檔」分頁中找到${1===_.items.length?\"它\":\"它們\"}。`"
   ],
   [
     "message:F?`歸檔 ${j.items.length} ${1===j.items.length?b.noun:b.nouns}？你可以在「已封存」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`",
-    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在「已封存」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在「已歸檔」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
   ],
   [
     "confirmText:F?\"Archive\":\"Delete\"",
@@ -545,15 +545,15 @@
   ],
   [
     "placeholder:\"Search projects\"",
-    "placeholder:\"搜尋項目\""
+    "placeholder:\"搜尋專案\""
   ],
   [
     "placeholder:\"Search projects...\"",
-    "placeholder:\"搜尋項目\""
+    "placeholder:\"搜尋專案\""
   ],
   [
     "placeholder:\"Search projects…\"",
-    "placeholder:\"搜尋項目\""
+    "placeholder:\"搜尋專案\""
   ],
   [
     "pr=\"Cloud\"",
@@ -801,7 +801,7 @@
   ],
   [
     "B1t={all:\"All\",active:\"Active\",archived:\"Archived\"}",
-    "B1t={all:\"全部\",active:\"活躍\",archived:\"已封存\"}"
+    "B1t={all:\"全部\",active:\"活躍\",archived:\"已歸檔\"}"
   ],
   [
     "DJt={all:\"All\",active:\"Active\",archived:\"Archived\"}",
@@ -809,7 +809,7 @@
   ],
   [
     "$1t={all:\"No tasks yet.\",active:\"No active tasks.\",archived:\"No archived tasks.\"}",
-    "$1t={all:\"還沒有任務。\",active:\"沒有活躍任務。\",archived:\"沒有已封存任務。\"}"
+    "$1t={all:\"還沒有任務。\",active:\"沒有活躍任務。\",archived:\"沒有已歸檔任務。\"}"
   ],
   [
     "children:\"Active\"}),renderRow",
@@ -821,7 +821,7 @@
   ],
   [
     "Sent on every inference and model-discovery request (joined into the CLI's `ANTHROPIC_CUSTOM_HEADERS`).\\n\\nUse this for fleet-wide constants. For per-user or per-session values, have the **credential helper script** emit JSON with a `headers` field; those are merged over these static entries (helper wins on conflict).",
-    "會傳送到每個推論與模型探索請求（會合併進 CLI 的 `ANTHROPIC_CUSTOM_HEADERS`）。\\n\\n用於全員固定常數。對於依使用者或依工作階段變動的值，請讓**憑證輔助腳本**輸出帶有 `headers` 欄位的 JSON；這些值會覆蓋這裡的靜態項目（衝突時輔助腳本優先）。"
+    "會傳送到每個推論與模型探索請求（會合併進 CLI 的 `ANTHROPIC_CUSTOM_HEADERS`）。\\n\\n用於全員固定常數。對於依使用者或依工作階段變動的值，請讓**憑證輔助腳本**輸出帶有 `headers` 欄位的 JSON；這些值會覆蓋這裡的靜態專案（衝突時輔助腳本優先）。"
   ],
   [
     "Claude runs the executable with no arguments and reads **stdout** (trimmed). Exit code must be `0`; any output on **stderr** is logged but ignored. **Stdout must contain only one of the formats below** (no banners, prompts, or log lines).\\n\\n**Output format** is either:\\n- a single bare token (the API key / bearer token), or\\n- a JSON object `{\"token\": \"...\", \"headers\": {\"Name\": \"Value\", ...}}` when per-request headers are needed (merged over **Custom inference headers**, helper wins on conflict)\\n\\nResult is cached for the TTL below. On TTL expiry the helper is re-invoked transparently (no user prompt, no relaunch).\\n\\n**Typical use:** a shell script that pulls from Keychain, 1Password CLI, or an internal secret broker. Example:\\n\\n`security find-generic-password -s anthropic-api -w`\\n\\nIf this field is set, static credential fields (API key, bearer token) are ignored. The helper always wins.",
@@ -857,7 +857,7 @@
   ],
   [
     "message:z?`Archive ${j.items.length} ${1===j.items.length?y.noun:y.nouns}? You can find ${1===j.items.length?\"it\":\"them\"} in the Archived tab.`",
-    "message:z?`歸檔 ${j.items.length} 個${1===j.items.length?y.noun:y.nouns}？你可以在「已封存」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+    "message:z?`歸檔 ${j.items.length} 個${1===j.items.length?y.noun:y.nouns}？你可以在「已歸檔」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
   ],
   [
     "Only affects **tool calls**. Inference and MCP traffic are covered by their own allowlists elsewhere.\\n\\nWhen unset, only the inference endpoint is reachable from the sandbox; the agent's package installs (pip/npm) and web fetches will fail with a 403.\\n\\nAccepts exact hostnames (`api.github.com`), wildcards (`*.corp.com` matches one subdomain level), and `*` to allow all.\\n\\nWildcards don't cross schemes. `*.corp.com` matches `docs.corp.com` but not `corp.com` itself; add both if you need the apex.\\n\\nIP literals and localhost always resolve regardless of this list; this is a public-egress filter, not a sandbox.\\n\\nHosts you add here also need to be open on your network firewall. See **Egress Requirements** for the full allowlist.",
@@ -865,7 +865,7 @@
   ],
   [
     "\\\"Essential\\\" means the signals Anthropic needs to keep your deployment working: **crash stacks**, **startup failure reasons**, and **version/OS metadata**. No prompts, completions, file contents, or identifiers beyond a random install ID.\\n\\n**What you lose when this is on:** when a Cowork build hits a bug that only reproduces on your OS version or locale, Anthropic can't see it unless a user manually reports. Fixes ship slower.\\n\\n**Why this is discouraged, not blocked:** some air-gapped environments require zero outbound telemetry as a matter of policy. The switch exists for them. If you don't have that constraint, leave it off.",
-    "「必要」指 Anthropic 維持你的部署正常運作所需的信號：**崩潰堆疊**、**啟動失敗原因**和**版本/OS 中繼資料**。不包含提示、補全、檔案內容，也不包含隨機安裝 ID 以外的識別碼。\\n\\n**啟用此項會失去什麼：** 當 Cowork 建置遇到只在你的 OS 版本或地區設定下重現的 bug 時，除非使用者手動回報，否則 Anthropic 看不到。修正發布會更慢。\\n\\n**為什麼不建議但不阻止：** 一些隔離網路環境因政策要求零輸出診斷資料。此開關就是為它們準備的。如果你沒有這個限制，請保持關閉。"
+    "「必要」指 Anthropic 維持你的部署正常運作所需的信號：**崩潰堆疊**、**啟動失敗原因**和**版本/OS 中繼資料**。不包含提示、補全、檔案內容，也不包含隨機安裝 ID 以外的識別碼。\\n\\n**啟用此項會失去什麼：** 當 Cowork 建置遇到只在你的 OS 版本或地區設定下重現的 bug 時，除非使用者手動回報，否則 Anthropic 看不到。修正發布會更慢。\\n\\n**為什麼不建議但不阻止：** 一些隔離網路環境因政策要求零輸出診斷資訊。此開關就是為它們準備的。如果你沒有這個限制，請保持關閉。"
   ],
   [
     "\"Nonessential\" covers two things: **product-usage analytics** (which features get used, navigation patterns; no prompts or completions) and the **Send** action in Help → Generate Diagnostic Report. Turning this on stops both.\\n\\nDestination for both: `claude.ai`. Already listed under Egress Requirements → Nonessential telemetry.",
@@ -1009,7 +1009,7 @@
   ],
   [
     "Bring relevant context and data from another AI provider to Claude. We'll provide a prompt you can use to fetch the memory from your other account.",
-    "將其他 AI 提供者中的相關脈絡和資料匯入 Claude。我們會提供一段提示，你可以用它從其他帳號擷取記憶。"
+    "將其他 AI 提供者中的相關脈絡和資訊匯入 Claude。我們會提供一段提示，你可以用它從其他帳號擷取記憶。"
   ],
   [
     "Start import",
@@ -1065,11 +1065,11 @@
   ],
   [
     "Archive 1 task? You can find it in the Archived tab.",
-    "要歸檔 1 個任務嗎？你可以在「已封存」分頁中找到它。"
+    "要歸檔 1 個任務嗎？你可以在「已歸檔」分頁中找到它。"
   ],
   [
     "message:F?`Archive ${j.items.length} ${1===j.items.length?y.noun:y.nouns}? You can find ${1===j.items.length?\"it\":\"them\"} in the Archived tab.`",
-    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?y.noun:y.nouns}？你可以在「已封存」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?y.noun:y.nouns}？你可以在「已歸檔」分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
   ],
   [
     "Cancel",
@@ -1250,5 +1250,493 @@
   [
     "Speed",
     "速度"
+  ],
+  [
+    "Add header",
+    "新增請求標頭"
+  ],
+  [
+    "Application",
+    "應用程式"
+  ],
+  [
+    "Allow Claude to automatically classify sessions as blocked, ready for review, or done. Classifying sessions counts towards your plan usage. Applies to new sessions.",
+    "允許 Claude 自動將工作階段分類為已阻止、待審核或已完成。分類工作階段會計入你的計劃用量。適用於新工作階段。"
+  ],
+  [
+    "Are you sure you want to delete 1 chat? This cannot be undone.",
+    "你確定要刪除 1 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Are you sure you want to delete {count} chat? This cannot be undone.",
+    "你確定要刪除 {count} 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Are you sure you want to delete {count} chats? This cannot be undone.",
+    "你確定要刪除 {count} 個聊天嗎？此操作無法復原。"
+  ],
+  [
+    "Authorization tokens",
+    "授權權杖"
+  ],
+  [
+    "Auto-archive after PR merge or close",
+    "PR 合併或關閉後自動歸檔"
+  ],
+  [
+    "Automatically archive desktop sessions when the associated pull request is merged or closed.",
+    "關聯的提取請求合併或關閉後，自動歸檔桌面工作階段。"
+  ],
+  [
+    "Autofix pull requests",
+    "自動修復提取請求"
+  ],
+  [
+    "Auto-populate the model picker from /v1/models at launch.",
+    "啟動時從 /v1/models 自動填入模型選擇器。"
+  ],
+  [
+    "Auto-populate the model picker from {url} at launch.",
+    "啟動時從 {url} 自動填入模型選擇器。"
+  ],
+  [
+    "Claude understands your codebase and helps you build, debug, and ship faster. Upgrade your plan to get started.",
+    "Claude 了解你的代碼庫，能幫助你更快地構建、調試和發布。升級你的計劃即可開始使用。"
+  ],
+  [
+    "Claude understands your codebase and helps you build, debug, and ship faster. Get started in the desktop app.",
+    "Claude 了解你的代碼庫，能幫助你更快地構建、調試和發布。請在桌面應用程式中開始使用。"
+  ],
+  [
+    "Claude Code (CLI, Desktop, IDE)",
+    "Claude Code（CLI、桌面版、IDE）"
+  ],
+  [
+    "Claude Light",
+    "Claude 淺色"
+  ],
+  [
+    "Claude Dark",
+    "Claude 深色"
+  ],
+  [
+    "Classify session states",
+    "分類工作階段狀態"
+  ],
+  [
+    "Created when you sign in to Claude Code. Revoke a token to sign out from that device.",
+    "登入 Claude Code 時創建。撤銷權杖即可讓該裝置退出登入。"
+  ],
+  [
+    "Choose where Claude Desktop sends inference requests.",
+    "選擇 Claude Desktop 將推理請求傳送到哪裡。"
+  ],
+  [
+    "Connection",
+    "連線"
+  ],
+  [
+    "Connectors & extensions",
+    "連接器與擴充功能"
+  ],
+  [
+    "Credential kind",
+    "憑證類型"
+  ],
+  [
+    "Custom inference headers",
+    "自訂推理請求標頭"
+  ],
+  [
+    "Default",
+    "預設"
+  ],
+  [
+    "Egress Requirements",
+    "輸出要求"
+  ],
+  [
+    "Extensions",
+    "擴充功能"
+  ],
+  [
+    "Extra HTTP headers sent on every inference request to the configured provider. For tenant routing, org IDs, Bedrock Guardrails, etc.",
+    "每次向所配置提供者傳送推理請求時附加的 HTTP 請求標頭。可用於租戶路由、組織 ID、Bedrock Guardrails 等場景。"
+  ],
+  [
+    "High-contrast dark theme",
+    "高對比度深色主題"
+  ],
+  [
+    "Use a darker, near-black background when dark mode is on.",
+    "開啟深色模式時使用更暗、接近黑色的背景。"
+  ],
+  [
+    "When you create a pull request, Claude automatically monitors it for CI failures and review comments, then responds proactively. Claude may post comments on your behalf.",
+    "創建提取請求後，Claude 會自動監控 CI 失敗和評審評論，並主動響應。Claude 可能會代表你發表評論。"
+  ],
+  [
+    "Browse extensions",
+    "瀏覽擴充功能"
+  ],
+  [
+    "Full URL of the inference gateway endpoint.",
+    "推理閘道端點的完整 URL。"
+  ],
+  [
+    "Gateway",
+    "閘道"
+  ],
+  [
+    "Gateway base URL",
+    "閘道基礎 URL"
+  ],
+  [
+    "GATEWAY CREDENTIALS",
+    "閘道憑證"
+  ],
+  [
+    "网关 credentials",
+    "閘道憑證"
+  ],
+  [
+    "{provider} credentials",
+    "{provider} 憑證"
+  ],
+  [
+    "Learn more",
+    "了解更多"
+  ],
+  [
+    "Model list",
+    "模型清單"
+  ],
+  [
+    "Models",
+    "模型"
+  ],
+  [
+    "Models to show in the picker. First entry is the default.",
+    "顯示在模型選擇器中的模型。第一項為預設模型。"
+  ],
+  [
+    "MODELS",
+    "模型"
+  ],
+  [
+    "Override the auto-discovered model list. First entry is the default.",
+    "覆蓋自動探索的模型清單。第一項為預設模型。"
+  ],
+  [
+    "Plugins & skills",
+    "外掛與技能"
+  ],
+  [
+    "Search settings",
+    "搜尋設定"
+  ],
+  [
+    "Selects the credential source. When set, only that source is used (no fallback).",
+    "選擇憑證來源。設定後只會使用該來源，不會回退。"
+  ],
+  [
+    "Telemetry & updates",
+    "診斷與更新"
+  ],
+  [
+    "Usage limits",
+    "使用限制"
+  ],
+  [
+    "Workspace restrictions",
+    "工作區限制"
+  ],
+  [
+    "Allow all",
+    "全部允許"
+  ],
+  [
+    "Allow Claude Code tab",
+    "允許 Claude Code 分頁"
+  ],
+  [
+    "Allow desktop extensions",
+    "允許桌面擴充功能"
+  ],
+  [
+    "Allow user-added MCP servers",
+    "允許使用者新增 MCP 伺服器"
+  ],
+  [
+    "Allowed egress hosts",
+    "允許的輸出主機"
+  ],
+  [
+    "Allowed workspace folders",
+    "允許的工作區資料夾"
+  ],
+  [
+    "AUTO-UPDATES",
+    "自動更新"
+  ],
+  [
+    "ANTHROPIC TELEMETRY",
+    "Anthropic 診斷資訊"
+  ],
+  [
+    "Block essential telemetry",
+    "阻止必要診斷資訊"
+  ],
+  [
+    "Block nonessential services",
+    "阻止非必要服務"
+  ],
+  [
+    "Block nonessential telemetry",
+    "阻止非必要診斷資訊"
+  ],
+  [
+    "Built-in tool policy",
+    "內建工具政策"
+  ],
+  [
+    "Built-in tools removed from Cowork.",
+    "從 Cowork 中移除的內建工具。"
+  ],
+  [
+    "Choose from disk",
+    "從磁碟選擇"
+  ],
+  [
+    "Choose...",
+    "選擇..."
+  ],
+  [
+    ".dxt and .mcpb installs.",
+    ".dxt 和 .mcpb 安裝包。"
+  ],
+  [
+    "Copy",
+    "複製"
+  ],
+  [
+    "CORE (VM BUNDLE + CLAUDE CLI BINARY)",
+    "核心（VM 包 + Claude CLI 二進位檔案）"
+  ],
+  [
+    "DESKTOP EXTENSIONS (PYTHON RUNTIME)",
+    "桌面擴充功能（Python 執行階段）"
+  ],
+  [
+    "Disable Claude.ai sign-in",
+    "停用 Claude.ai 登入"
+  ],
+  [
+    "Disable claude:// deep-link handling",
+    "停用 claude:// 深層連結處理"
+  ],
+  [
+    "Disabled built-in tools",
+    "停用內建工具"
+  ],
+  [
+    "Domains Cowork's tools may reach during a turn. Also surfaced under Egress Requirements.",
+    "Cowork 的工具在一次任務中可以訪問的網域。也會顯示在輸出要求中。"
+  ],
+  [
+    "Domains Cowork's tools may reach during a turn. Also surfaced under 出站要求.",
+    "Cowork 的工具在一次任務中可以訪問的網域。也會顯示在輸出要求中。"
+  ],
+  [
+    "ESSENTIAL TELEMETRY",
+    "必要診斷資訊"
+  ],
+  [
+    "EXTENSIONS",
+    "擴充功能"
+  ],
+  [
+    "Favicon fetch and the artifact-preview iframe origin. Artifacts will not render.",
+    "獲取網站圖示和 Artifact 預覽 iframe 來源。Artifacts 將無法渲染。"
+  ],
+  [
+    "Folders users may attach as a workspace. Leave unset for unrestricted access.",
+    "使用者可作為工作區附加的資料夾。留空則不限制。"
+  ],
+  [
+    "Hosts your network firewall must allow, derived from your current settings. This list is read-only and updates as you make changes. Traffic is HTTPS on port 443 unless a custom port is specified (OTLP, gateway, or MCP server URLs).",
+    "根據當前設定生成的網絡防火牆允許清單。此清單為唯讀，並會隨配置變更自動更新。除非指定了自訂端口（OTLP、閘道或 MCP 伺服器 URL），否則流量均為 443 端口上的 HTTPS。"
+  ],
+  [
+    "Local stdio servers added via the Developer settings. Remote servers come from the managed list above, or plugins mounted to a user's computer by an organization admin.",
+    "通過開發者設定新增的本地 stdio 伺服器。遠端伺服器來自上方託管清單，或來自組織管理員掛載到使用者電腦上的外掛。"
+  ],
+  [
+    "Managed MCP servers",
+    "託管的 MCP 伺服器"
+  ],
+  [
+    "Max tokens per window",
+    "每個視窗最大權杖數"
+  ],
+  [
+    "MCP SERVERS",
+    "MCP 伺服器"
+  ],
+  [
+    "Mount plugin bundles to this folder using your device-management tool and Cowork will load them at launch. The folder is read-only; tool policies you set below are saved in this configuration.",
+    "使用裝置管理工具將外掛包掛載到此資料夾，Cowork 會在啟動時載入。該資料夾為唯讀；下面設定的工具政策會保存在此配置中。"
+  ],
+  [
+    "NONESSENTIAL SERVICES",
+    "非必要服務"
+  ],
+  [
+    "NONESSENTIAL TELEMETRY",
+    "非必要診斷資訊"
+  ],
+  [
+    "ORGANIZATION PLUGINS",
+    "組織外掛"
+  ],
+  [
+    "Organization UUID",
+    "組織 UUID"
+  ],
+  [
+    "Org-pushed MCP servers: remote (HTTP/SSE) or local (stdio command). May embed bearer tokens.",
+    "組織推送的 MCP 伺服器：遠端（HTTP/SSE）或本地（stdio 命令）。可能嵌入 Bearer 權杖。"
+  ],
+  [
+    "Per-tool approval policy. \"ask\" requires user approval before each call; \"allow\" is the default. Use Disabled built-in tools to remove a tool entirely.",
+    "按工具設定的核准政策。\"ask\" 表示每次調用前都需要使用者核准；\"allow\" 為預設值。如需完全移除某個工具，請使用“停用內建工具”。"
+  ],
+  [
+    "Per-user soft cap, counted client-side over the duration below. Not a server-enforced quota.",
+    "按使用者設定的軟上限，會在下方時長內由客戶端統計。不是伺服器強制執行的配額。"
+  ],
+  [
+    "Product-usage analytics and diagnostic-report uploads. No message content.",
+    "產品使用分析和診斷報告上傳。不包含訊息內容。"
+  ],
+  [
+    "Prompts, completions, and your data are never sent to Anthropic. Telemetry covers crash and usage signals only.",
+    "提示、補全和你的資料絕不會傳送給 Anthropic。診斷資訊只包含崩潰和使用信號。"
+  ],
+  [
+    "Reject desktop extensions that are not signed by a trusted publisher.",
+    "拒絕未由受信任發行者簽署的桌面擴充功能。"
+  ],
+  [
+    "Require signed extensions",
+    "要求擴充功能已簽署"
+  ],
+  [
+    "Show the Code tab (terminal-based coding sessions). Sessions run on the host, not inside the VM.",
+    "顯示 Code 分頁（基於終端的編碼工作階段）。工作階段在主機上執行，不在 VM 內執行。"
+  ],
+  [
+    "Tags telemetry events with your organization's UUID so Anthropic support can find them. Not used for auth.",
+    "使用你組織的 UUID 標記診斷資訊事件，方便 Anthropic 支援人員定位。不會用於認證。"
+  ],
+  [
+    "tokens",
+    "權杖"
+  ],
+  [
+    "Users see only this provider at the login screen. The option to sign in to Claude.ai is hidden.",
+    "使用者在登入頁只會看到此提供者。Claude.ai 登入選項會被隱藏。"
+  ],
+  [
+    "Crash and performance reports to Anthropic.",
+    "傳送給 Anthropic 的崩潰和效能報告。"
+  ],
+  [
+    "Add server policy",
+    "新增伺服器政策"
+  ],
+  [
+    "+ Add server policy",
+    "+ 新增伺服器政策"
+  ],
+  [
+    "Add policy",
+    "新增政策"
+  ],
+  [
+    "Anthropic telemetry",
+    "Anthropic 診斷資訊"
+  ],
+  [
+    "OpenTelemetry",
+    "OpenTelemetry 診斷資訊"
+  ],
+  [
+    "OpenTelemetry collector endpoint",
+    "OpenTelemetry 收集器端點"
+  ],
+  [
+    "Where Cowork sends OpenTelemetry logs and metrics. Leave blank to disable.",
+    "Cowork 傳送 OpenTelemetry 日誌和指標的位置。留空則停用。"
+  ],
+  [
+    "Updates",
+    "更新"
+  ],
+  [
+    "Block auto-updates",
+    "阻止自動更新"
+  ],
+  [
+    "Stop Cowork from fetching updates. You'll need to push new versions yourself.",
+    "阻止 Cowork 獲取更新。你需要自行推送新版本。"
+  ],
+  [
+    "Auto-update enforcement window",
+    "自動更新強制時窗"
+  ],
+  [
+    "Hours before a downloaded update force-installs. Blank = 72-hour default.",
+    "已下載更新在強制安裝前等待的小時數。留空則預設為 72 小時。"
+  ],
+  [
+    "<b>{category}</b> needs {count, plural, one {{label}} other {# fields}}",
+    "<b>{category}</b> 需要 {count, plural, one {{label}} other {# 個欄位}}"
+  ],
+  [
+    "Per-tool approval policy. \"ask\" requires user approval before each call; \"allow\" is the default. Use 禁用内置工具 to remove a tool entirely.",
+    "按工具設定的核准政策。“ask” 表示每次調用前都需要使用者核准；“allow” 為預設值。如需完全移除某個工具，請使用“停用內建工具”。"
+  ],
+  [
+    "Hi! How can I help you today?",
+    "你好！今天我能為你提供什麼幫助？"
+  ],
+  [
+    "Write a message...",
+    "輸入訊息..."
+  ],
+  [
+    "Write a message…",
+    "輸入訊息..."
+  ],
+  [
+    "message:F?`归档 ${j.items.length} ${1===j.items.length?b.noun:b.nouns}？你可以在“已归档”标签页中找到${1===j.items.length?\"它\":\"它们\"}。`",
+    "message:F?`歸檔 ${j.items.length} 個${1===j.items.length?b.noun:b.nouns}？你可以在“已歸檔”分頁中找到${1===j.items.length?\"它\":\"它們\"}。`"
+  ],
+  [
+    "CR={local:\"Local\",remote:\"Cloud\",bridge:\"Remote Control\",slack:\"Slack\"}",
+    "CR={local:\"本地\",remote:\"雲端\",bridge:\"遠端控制\",slack:\"Slack\"}"
+  ],
+  [
+    "\"Run tasks on a schedule or whenever you need them.\"",
+    "\"按排程或在需要時執行任務。\""
+  ],
+  [
+    "\"Run tasks on a schedule or whenever you need them. Type /schedule in any existing task to set one up.\"",
+    "\"按排程執行任務，或在需要時執行任務。在任意現有任務中輸入 /schedule 即可設定。\""
+  ],
+  [
+    "defaultMessage:\"All environments\",id:\"SBWkijOQlK\"",
+    "defaultMessage:\"所有環境\",id:\"SBWkijOQlK\""
   ]
 ]

--- a/resources/frontend-zh-HK.json
+++ b/resources/frontend-zh-HK.json
@@ -16051,5 +16051,9 @@
   "kslGQK9o7I": "每日簡報、每週回顧。將任一任務設置為按排程執行。",
   "uiBsm/q1Ed": "手動設定",
   "w0NtlmPvm/": "搜尋任務...",
-  "wFRNQOXDcp": "搜尋排程任務…"
+  "wFRNQOXDcp": "搜尋排程任務…",
+  "SBWkijOQlK": "所有環境",
+  "btDLI+exL1": "暫無排程任務。",
+  "bvhdbswdqH": "按排程或在需要時執行任務。",
+  "bw+L0wLpiO": "設定一個持續工作的空間，讓上下文隨時間積累。"
 }

--- a/resources/frontend-zh-TW.json
+++ b/resources/frontend-zh-TW.json
@@ -16051,5 +16051,9 @@
   "kslGQK9o7I": "每日簡報、每週回顧。將任一任務設定為按排程執行。",
   "uiBsm/q1Ed": "手動設定",
   "w0NtlmPvm/": "搜尋任務...",
-  "wFRNQOXDcp": "搜尋排程任務…"
+  "wFRNQOXDcp": "搜尋排程任務…",
+  "SBWkijOQlK": "所有環境",
+  "btDLI+exL1": "暫無排程任務。",
+  "bvhdbswdqH": "按排程或在需要時執行任務。",
+  "bw+L0wLpiO": "設定一個持續工作的空間，讓上下文隨時間累積。"
 }

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -126,10 +126,10 @@ Test-GitHubReleaseUpdate
 function Read-InteractiveSelection {
     Write-Host "=== Claude Desktop Windows 中文补丁 ==="
     Write-Host ""
-    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：Cowork 兼容（跳过 app.asar 补丁，第三方模型请用网关或 ccswitch 别名映射）)"
+    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：(Cowork 兼容Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
-    Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
+    # Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
     Write-Host "[Q] 退出"
     Write-Host ""
@@ -1335,8 +1335,8 @@ function Get-OnlineDomTranslationScript {
         $deleteChatConfirmText = "你确定要删除 `$1 个聊天吗？此操作无法撤消。"
         $deleteThisChatConfirmText = "你确定要永久删除此聊天吗？此操作无法撤消。"
         $deleteTheseChatsConfirmText = "你确定要永久删除这些聊天吗？此操作无法撤消。"
-        $archiveTaskText = "要归档 `$1 个任务吗？你可以在"已归档"标签页中找到它。"
-        $archiveTasksText = "要归档 `$1 个任务吗？你可以在"已归档"标签页中找到它们。"
+        $archiveTaskText = '要归档 $1 个任务吗？你可以在"已归档"标签页中找到它。'
+        $archiveTasksText = '要归档 $1 个任务吗？你可以在"已归档"标签页中找到它们。'
     } elseif ($Language -eq "zh-TW") {
         $selectedText = "已選擇 `$1 項"
         $deleteSelectedText = "刪除 `$1 個所選項目"

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -170,8 +170,6 @@ function Read-InteractiveSelection {
     }
 
     Write-Host ""
-    Invoke-PreInstallCleanup
-    Write-Host ""
     Write-Host "请选择要安装的语言："
     Write-Host "[1] 简体中文"
     Write-Host "[2] 繁体中文（中国台湾）"
@@ -182,9 +180,9 @@ function Read-InteractiveSelection {
     while ($true) {
         $languageSelection = (Read-Host "请选择语言 [1/2/3/Q]").Trim()
         switch -Regex ($languageSelection) {
-            '^[1]$' { return @{ Action = "install"; Language = "zh-CN"; PatchMode = $patchModeForInstall } }
-            '^[2]$' { return @{ Action = "install"; Language = "zh-TW"; PatchMode = $patchModeForInstall } }
-            '^[3]$' { return @{ Action = "install"; Language = "zh-HK"; PatchMode = $patchModeForInstall } }
+            '^[1]$' { Invoke-PreInstallCleanup; return @{ Action = "install"; Language = "zh-CN"; PatchMode = $patchModeForInstall } }
+            '^[2]$' { Invoke-PreInstallCleanup; return @{ Action = "install"; Language = "zh-TW"; PatchMode = $patchModeForInstall } }
+            '^[3]$' { Invoke-PreInstallCleanup; return @{ Action = "install"; Language = "zh-HK"; PatchMode = $patchModeForInstall } }
             '^[Qq]$' { exit 0 }
             default { Write-Host "请输入 1、2、3 或 Q。" -ForegroundColor Yellow }
         }
@@ -1325,46 +1323,116 @@ function Get-OnlineDomTranslationScript {
     if ($Language -eq "zh-CN") {
         $selectedText = "已选择 `$1 项"
         $deleteSelectedText = "删除 `$1 个所选项目"
+        $morningGreeting = "早上好，`$1"
+        $afternoonGreeting = "下午好，`$1"
+        $eveningGreeting = "晚上好，`$1"
+        $lateNightGreeting = "夜深了，`$1"
+        $goodNightGreeting = "晚安，`$1"
+        $deleteChatText = "删除 `$1 个聊天"
+        $moveChatText = "将 `$1 个聊天移至项目"
+        $connNeedsFieldText = "连接还需要填写 `$1 个字段"
+        $needsFieldText = "还需要填写 `$1 个字段"
+        $deleteChatConfirmText = "你确定要删除 `$1 个聊天吗？此操作无法撤消。"
+        $deleteThisChatConfirmText = "你确定要永久删除此聊天吗？此操作无法撤消。"
+        $deleteTheseChatsConfirmText = "你确定要永久删除这些聊天吗？此操作无法撤消。"
+        $archiveTaskText = "要归档 `$1 个任务吗？你可以在"已归档"标签页中找到它。"
+        $archiveTasksText = "要归档 `$1 个任务吗？你可以在"已归档"标签页中找到它们。"
+    } elseif ($Language -eq "zh-TW") {
+        $selectedText = "已選擇 `$1 項"
+        $deleteSelectedText = "刪除 `$1 個所選項目"
+        $morningGreeting = "早安，`$1"
+        $afternoonGreeting = "午安，`$1"
+        $eveningGreeting = "晚安，`$1"
+        $lateNightGreeting = "夜深了，`$1"
+        $goodNightGreeting = "晚安，`$1"
+        $deleteChatText = "刪除 `$1 個聊天"
+        $moveChatText = "將 `$1 個聊天移至專案"
+        $connNeedsFieldText = "連線還需要填寫 `$1 個欄位"
+        $needsFieldText = "還需要填寫 `$1 個欄位"
+        $deleteChatConfirmText = "你確定要刪除 `$1 個聊天嗎？此操作無法復原。"
+        $deleteThisChatConfirmText = "你確定要永久刪除此聊天嗎？此操作無法復原。"
+        $deleteTheseChatsConfirmText = "你確定要永久刪除這些聊天嗎？此操作無法復原。"
+        $archiveTaskText = "要歸檔 `$1 個任務嗎？你可以在「已歸檔」分頁中找到它。"
+        $archiveTasksText = "要歸檔 `$1 個任務嗎？你可以在「已歸檔」分頁中找到它們。"
     } else {
         $selectedText = "已選擇 `$1 項"
         $deleteSelectedText = "刪除 `$1 個所選項目"
+        $morningGreeting = "早晨，`$1"
+        $afternoonGreeting = "午安，`$1"
+        $eveningGreeting = "晚安，`$1"
+        $lateNightGreeting = "夜深了，`$1"
+        $goodNightGreeting = "晚安，`$1"
+        $deleteChatText = "刪除 `$1 個聊天"
+        $moveChatText = "將 `$1 個聊天移至項目"
+        $connNeedsFieldText = "連線還需要填寫 `$1 個欄位"
+        $needsFieldText = "還需要填寫 `$1 個欄位"
+        $deleteChatConfirmText = "你確定要刪除 `$1 個聊天嗎？此操作無法復原。"
+        $deleteThisChatConfirmText = "你確定要永久刪除此聊天嗎？此操作無法復原。"
+        $deleteTheseChatsConfirmText = "你確定要永久刪除這些聊天嗎？此操作無法復原。"
+        $archiveTaskText = "要歸檔 `$1 個任務嗎？你可以在「已封存」分頁中找到它。"
+        $archiveTasksText = "要歸檔 `$1 個任務嗎？你可以在「已封存」分頁中找到它們。"
     }
     $selectedTextJson = $selectedText | ConvertTo-Json -Compress
     $deleteSelectedTextJson = $deleteSelectedText | ConvertTo-Json -Compress
+    $morningGreetingJson = $morningGreeting | ConvertTo-Json -Compress
+    $afternoonGreetingJson = $afternoonGreeting | ConvertTo-Json -Compress
+    $eveningGreetingJson = $eveningGreeting | ConvertTo-Json -Compress
+    $lateNightGreetingJson = $lateNightGreeting | ConvertTo-Json -Compress
+    $goodNightGreetingJson = $goodNightGreeting | ConvertTo-Json -Compress
+    $deleteChatTextJson = $deleteChatText | ConvertTo-Json -Compress
+    $moveChatTextJson = $moveChatText | ConvertTo-Json -Compress
+    $connNeedsFieldTextJson = $connNeedsFieldText | ConvertTo-Json -Compress
+    $needsFieldTextJson = $needsFieldText | ConvertTo-Json -Compress
+    $deleteChatConfirmTextJson = $deleteChatConfirmText | ConvertTo-Json -Compress
+    $deleteThisChatConfirmTextJson = $deleteThisChatConfirmText | ConvertTo-Json -Compress
+    $deleteTheseChatsConfirmTextJson = $deleteTheseChatsConfirmText | ConvertTo-Json -Compress
+    $archiveTaskTextJson = $archiveTaskText | ConvertTo-Json -Compress
+    $archiveTasksTextJson = $archiveTasksText | ConvertTo-Json -Compress
     $template = @'
 (()=>{try{
 const L=__LANGUAGE__,M=__MAPPING__,ST=__SELECTED_TEXT__,DST=__DELETE_SELECTED_TEXT__;
-localStorage.setItem("spa:locale",L);
-document.documentElement&&document.documentElement.setAttribute("lang",L);
-const N=s=>(s||"").replace(/\s+/g," ").trim();
+localStorage.setItem(“spa:locale”,L);
+document.documentElement&&document.documentElement.setAttribute(“lang”,L);
+const N=s=>(s||””).replace(/\s+/g,” “).trim();
 const G=[
-[/^Morning, (.+)$/,"早上好，$1"],[/^Good morning, (.+)$/,"早上好，$1"],
-[/^Afternoon, (.+)$/,"下午好，$1"],[/^Good afternoon, (.+)$/,"下午好，$1"],
-[/^Evening, (.+)$/,"晚上好，$1"],[/^Good evening, (.+)$/,"晚上好，$1"],
-[/^It's late-night (.+)$/,"夜深了，$1"],[/^Good night, (.+)$/,"晚安，$1"],
-[/^Delete (\d+) chat$/,"删除 $1 个聊天"],[/^Delete (\d+) chats$/,"删除 $1 个聊天"],
-[/^Move (\d+) chat to a project$/,"将 $1 个聊天移至项目"],[/^Move (\d+) chats to a project$/,"将 $1 个聊天移至项目"],
-[/^Connection needs (\d+) field$/,"连接还需要填写 $1 个字段"],[/^Connection needs (\d+) fields$/,"连接还需要填写 $1 个字段"],
-[/^needs (\d+) field$/,"还需要填写 $1 个字段"],[/^needs (\d+) fields$/,"还需要填写 $1 个字段"],
-[/^Are you sure you want to delete (\d+) chat\? This cannot be undone\.$/,"你确定要删除 $1 个聊天吗？此操作无法撤消。"],
-[/^Are you sure you want to delete (\d+) chats\? This cannot be undone\.$/,"你确定要删除 $1 个聊天吗？此操作无法撤消。"],
-[/^Are you sure you want to permanently delete this chat\? This cannot be undone\.$/,"你确定要永久删除此聊天吗？此操作无法撤消。"],
-[/^Are you sure you want to permanently delete these chats\? This cannot be undone\.$/,"你确定要永久删除这些聊天吗？此操作无法撤消。"],
-[/^Archive (\d+) task\? You can find it in the Archived tab\.$/,"要归档 $1 个任务吗？你可以在“已归档”标签页中找到它。"],
-[/^Archive (\d+) tasks\? You can find them in the Archived tab\.$/,"要归档 $1 个任务吗？你可以在“已归档”标签页中找到它们。"],
+[/^Morning, (.+)$/,__MORNING__],[/^Good morning, (.+)$/,__MORNING__],
+[/^Afternoon, (.+)$/,__AFTERNOON__],[/^Good afternoon, (.+)$/,__AFTERNOON__],
+[/^Evening, (.+)$/,__EVENING__],[/^Good evening, (.+)$/,__EVENING__],
+[/^It's late-night (.+)$/,__LATENIGHT__],[/^Good night, (.+)$/,__GOODNIGHT__],
+[/^Delete (\d+) chat$/,__DELETE_CHAT__],[/^Delete (\d+) chats$/,__DELETE_CHAT__],
+[/^Move (\d+) chat to a project$/,__MOVE_CHAT__],[/^Move (\d+) chats to a project$/,__MOVE_CHAT__],
+[/^Connection needs (\d+) field$/,__CONN_NEEDS_FIELD__],[/^Connection needs (\d+) fields$/,__CONN_NEEDS_FIELD__],
+[/^needs (\d+) field$/,__NEEDS_FIELD__],[/^needs (\d+) fields$/,__NEEDS_FIELD__],
+[/^Are you sure you want to delete (\d+) chat\? This cannot be undone\.$/,__DELETE_CHAT_CONFIRM__],
+[/^Are you sure you want to delete (\d+) chats\? This cannot be undone\.$/,__DELETE_CHAT_CONFIRM__],
+[/^Are you sure you want to permanently delete this chat\? This cannot be undone\.$/,__DELETE_THIS_CHAT_CONFIRM__],
+[/^Are you sure you want to permanently delete these chats\? This cannot be undone\.$/,__DELETE_THESE_CHAT_CONFIRM__],
+[/^Archive (\d+) task\? You can find it in the Archived tab\.$/,__ARCHIVE_TASK__],
+[/^Archive (\d+) tasks\? You can find them in the Archived tab\.$/,__ARCHIVE_TASKS__],
 [/^(\d+) selected$/,ST],
 [/^Delete (\d+) selected item$/,DST],
 [/^Delete (\d+) selected items$/,DST],
-[/^Mon$/,"周一"],[/^Tue$/,"周二"],[/^Wed$/,"周三"],[/^Thu$/,"周四"],[/^Fri$/,"周五"],[/^Sat$/,"周六"],[/^Sun$/,"周日"]
+[/^Mon$/,__MON__],[/^Tue$/,__TUE__],[/^Wed$/,__WED__],[/^Thu$/,__THU__],[/^Fri$/,__FRI__],[/^Sat$/,__SAT__],[/^Sun$/,__SUN__]
 ];
-const R=s=>{const n=N(s);if(M[n])return M[n];for(const [r,t] of G){const m=n.match(r);if(m)return t.replace("$1",m[1])}};
-const X=new Set(["SCRIPT","STYLE","NOSCRIPT"]);
-function T(){try{const b=document.body||document.documentElement;if(!b)return;const w=document.createTreeWalker(b,NodeFilter.SHOW_TEXT,{acceptNode(n){const p=n.parentElement;if(!p||X.has(p.tagName)||!R(n.nodeValue))return NodeFilter.FILTER_REJECT;return NodeFilter.FILTER_ACCEPT}});let n;while(n=w.nextNode()){const v=R(n.nodeValue);if(v)n.nodeValue=v}document.querySelectorAll("[role=dialog] p,[role=dialog] div,[role=dialog] span").forEach(e=>{try{if(e.closest("button,[contenteditable]"))return;const t=R(e.textContent);if(t&&N(e.textContent)!==N(t))e.textContent=t}catch{}});document.querySelectorAll("[aria-label],[title],[placeholder],input,textarea").forEach(e=>{["aria-label","title","placeholder","value"].forEach(a=>{try{if(a==="value"&&!(e.matches("input[type=button],input[type=submit]")))return;let v=e.getAttribute?e.getAttribute(a):void 0;if(v==null&&a in e)v=e[a];const t=R(v);if(t){if(e.setAttribute)e.setAttribute(a,t);try{if(a in e)e[a]=t}catch{}}}catch{}})});document.querySelectorAll("a").forEach(e=>{try{const r=e.getBoundingClientRect(),txt=N(e.textContent);if(txt==="Claude"&&r.left<100&&r.top<100)e.style.visibility="hidden"}catch{}})}catch{}}
+const R=s=>{const n=N(s);if(M[n])return M[n];for(const [r,t] of G){const m=n.match(r);if(m)return t.replace(“$1”,m[1])}};
+const X=new Set([“SCRIPT”,”STYLE”,”NOSCRIPT”]);
+function T(){try{const b=document.body||document.documentElement;if(!b)return;const w=document.createTreeWalker(b,NodeFilter.SHOW_TEXT,{acceptNode(n){const p=n.parentElement;if(!p||X.has(p.tagName)||!R(n.nodeValue))return NodeFilter.FILTER_REJECT;return NodeFilter.FILTER_ACCEPT}});let n;while(n=w.nextNode()){const v=R(n.nodeValue);if(v)n.nodeValue=v}document.querySelectorAll(“[role=dialog] p,[role=dialog] div,[role=dialog] span”).forEach(e=>{try{if(e.closest(“button,[contenteditable]”))return;const t=R(e.textContent);if(t&&N(e.textContent)!==N(t))e.textContent=t}catch{}});document.querySelectorAll(“[aria-label],[title],[placeholder],input,textarea”).forEach(e=>{[“aria-label”,”title”,”placeholder”,”value”].forEach(a=>{try{if(a===”value”&&!(e.matches(“input[type=button],input[type=submit]”)))return;let v=e.getAttribute?e.getAttribute(a):void 0;if(v==null&&a in e)v=e[a];const t=R(v);if(t){if(e.setAttribute)e.setAttribute(a,t);try{if(a in e)e[a]=t}catch{}}}catch{}})});document.querySelectorAll(“a”).forEach(e=>{try{const r=e.getBoundingClientRect(),txt=N(e.textContent);if(txt===”Claude”&&r.left<100&&r.top<100)e.style.visibility=”hidden”}catch{}})}catch{}}
 T();
 new MutationObserver(()=>{clearTimeout(window.__claudeZhDomTimer);window.__claudeZhDomTimer=setTimeout(T,30)}).observe(document.documentElement,{subtree:true,childList:true,characterData:true,attributes:true});
 }catch(e){}})()
 '@
-    return $template.Replace("__LANGUAGE__", $languageJson).Replace("__MAPPING__", $mappingJson).Replace("__SELECTED_TEXT__", $selectedTextJson).Replace("__DELETE_SELECTED_TEXT__", $deleteSelectedTextJson)
+    # weekday labels
+    if ($Language -eq "zh-CN") {
+        $weekdayJson = @{
+            Mon = "周一"; Tue = "周二"; Wed = "周三"; Thu = "周四"; Fri = "周五"; Sat = "周六"; Sun = "周日"
+        }
+    } else {
+        $weekdayJson = @{
+            Mon = "週一"; Tue = "週二"; Wed = "週三"; Thu = "週四"; Fri = "週五"; Sat = "週六"; Sun = "週日"
+        }
+    }
+
+    return $template.Replace("__LANGUAGE__", $languageJson).Replace("__MAPPING__", $mappingJson).Replace("__SELECTED_TEXT__", $selectedTextJson).Replace("__DELETE_SELECTED_TEXT__", $deleteSelectedTextJson).Replace("__MORNING__", $morningGreetingJson).Replace("__AFTERNOON__", $afternoonGreetingJson).Replace("__EVENING__", $eveningGreetingJson).Replace("__LATENIGHT__", $lateNightGreetingJson).Replace("__GOODNIGHT__", $goodNightGreetingJson).Replace("__DELETE_CHAT__", $deleteChatTextJson).Replace("__MOVE_CHAT__", $moveChatTextJson).Replace("__CONN_NEEDS_FIELD__", $connNeedsFieldTextJson).Replace("__NEEDS_FIELD__", $needsFieldTextJson).Replace("__DELETE_CHAT_CONFIRM__", $deleteChatConfirmTextJson).Replace("__DELETE_THIS_CHAT_CONFIRM__", $deleteThisChatConfirmTextJson).Replace("__DELETE_THESE_CHAT_CONFIRM__", $deleteTheseChatsConfirmTextJson).Replace("__ARCHIVE_TASK__", $archiveTaskTextJson).Replace("__ARCHIVE_TASKS__", $archiveTasksTextJson).Replace("__MON__", ($weekdayJson.Mon | ConvertTo-Json -Compress)).Replace("__TUE__", ($weekdayJson.Tue | ConvertTo-Json -Compress)).Replace("__WED__", ($weekdayJson.Wed | ConvertTo-Json -Compress)).Replace("__THU__", ($weekdayJson.Thu | ConvertTo-Json -Compress)).Replace("__FRI__", ($weekdayJson.Fri | ConvertTo-Json -Compress)).Replace("__SAT__", ($weekdayJson.Sat | ConvertTo-Json -Compress)).Replace("__SUN__", ($weekdayJson.Sun | ConvertTo-Json -Compress))
 }
 
 function Remove-ExistingOnlineDomTranslationPatch {

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -126,9 +126,10 @@ Test-GitHubReleaseUpdate
 function Read-InteractiveSelection {
     Write-Host "=== Claude Desktop Windows 中文补丁 ==="
     Write-Host ""
-    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：（Cowork 沙箱/工作区不可用(看群公告))"
+    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：Cowork 兼容（跳过 app.asar 补丁，第三方模型请用网关或 ccswitch 别名映射）)"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
+    Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
     Write-Host "[Q] 退出"
     Write-Host ""

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -537,46 +537,103 @@ def build_online_dom_translation_script(lang_code: str, mapping: dict[str, str])
         delete_named_session_text = "“$1”将被永久删除。此操作无法撤消。"
         archive_selected_tasks_text = "归档所选任务？"
         archive_tasks_moved_text = "$1 个任务将被移至“已归档”。"
-    else:
+        morning_greeting = "早上好，$1"
+        afternoon_greeting = "下午好，$1"
+        evening_greeting = "晚上好，$1"
+        late_night_greeting = "夜深了，$1"
+        good_night_greeting = "晚安，$1"
+        delete_chat_text = "删除 $1 个聊天"
+        move_chat_text = "将 $1 个聊天移至项目"
+        conn_needs_field_text = "连接还需要填写 $1 个字段"
+        needs_field_text = "还需要填写 $1 个字段"
+        delete_chat_confirm_text = "你确定要删除 $1 个聊天吗？此操作无法撤消。"
+        delete_this_chat_confirm_text = "你确定要永久删除此聊天吗？此操作无法撤消。"
+        delete_these_chats_confirm_text = "你确定要永久删除这些聊天吗？此操作无法撤消。"
+        archive_task_text = "要归档 $1 个任务吗？你可以在“已归档”标签页中找到它。"
+        archive_tasks_text = "要归档 $1 个任务吗？你可以在“已归档”标签页中找到它们。"
+        weekday_labels = '["周一","周二","周三","周四","周五","周六","周日"]'
+    elif lang_code == "zh-TW":
         selected_text = "已選擇 $1 項"
         delete_selected_text = "刪除 $1 個所選項目"
         delete_sessions_text = "刪除 $1 個工作階段？"
         delete_named_session_text = "「$1」將被永久刪除。此操作無法復原。"
         archive_selected_tasks_text = "歸檔所選任務？"
         archive_tasks_moved_text = "$1 個任務將被移至「已歸檔」。"
+        morning_greeting = "早安，$1"
+        afternoon_greeting = "午安，$1"
+        evening_greeting = "晚安，$1"
+        late_night_greeting = "夜深了，$1"
+        good_night_greeting = "晚安，$1"
+        delete_chat_text = "刪除 $1 個聊天"
+        move_chat_text = "將 $1 個聊天移至專案"
+        conn_needs_field_text = "連線還需要填寫 $1 個欄位"
+        needs_field_text = "還需要填寫 $1 個欄位"
+        delete_chat_confirm_text = "你確定要刪除 $1 個聊天嗎？此操作無法復原。"
+        delete_this_chat_confirm_text = "你確定要永久刪除此聊天嗎？此操作無法復原。"
+        delete_these_chats_confirm_text = "你確定要永久刪除這些聊天嗎？此操作無法復原。"
+        archive_task_text = "要歸檔 $1 個任務嗎？你可以在「已歸檔」分頁中找到它。"
+        archive_tasks_text = "要歸檔 $1 個任務嗎？你可以在「已歸檔」分頁中找到它們。"
+        weekday_labels = '["週一","週二","週三","週四","週五","週六","週日"]'
+    else:  # zh-HK
+        selected_text = "已選擇 $1 項"
+        delete_selected_text = "刪除 $1 個所選項目"
+        delete_sessions_text = "刪除 $1 個工作階段？"
+        delete_named_session_text = "「$1」將被永久刪除。此操作無法復原。"
+        archive_selected_tasks_text = "歸檔所選任務？"
+        archive_tasks_moved_text = "$1 個任務將被移至「已封存」。"
+        morning_greeting = "早晨，$1"
+        afternoon_greeting = "午安，$1"
+        evening_greeting = "晚安，$1"
+        late_night_greeting = "夜深了，$1"
+        good_night_greeting = "晚安，$1"
+        delete_chat_text = "刪除 $1 個聊天"
+        move_chat_text = "將 $1 個聊天移至項目"
+        conn_needs_field_text = "連線還需要填寫 $1 個欄位"
+        needs_field_text = "還需要填寫 $1 個欄位"
+        delete_chat_confirm_text = "你確定要刪除 $1 個聊天嗎？此操作無法復原。"
+        delete_this_chat_confirm_text = "你確定要永久刪除此聊天嗎？此操作無法復原。"
+        delete_these_chats_confirm_text = "你確定要永久刪除這些聊天嗎？此操作無法復原。"
+        archive_task_text = "要歸檔 $1 個任務嗎？你可以在「已封存」分頁中找到它。"
+        archive_tasks_text = "要歸檔 $1 個任務嗎？你可以在「已封存」分頁中找到它們。"
+        weekday_labels = '["週一","週二","週三","週四","週五","週六","週日"]'
     dynamic_rules = "".join((
         f'[/^(\\d+) selected$/,"{selected_text}"],'
         f'[/^Delete (\\d+) selected item$/,"{delete_selected_text}"],'
         f'[/^Delete (\\d+) selected items$/,"{delete_selected_text}"],'
         f'[/^Delete (\\d+) sessions?\\?$/,"{delete_sessions_text}"],'
-        f'[/^[“\\"](.+?)[”\\"] will be permanently deleted\\. This can[’\\\']t be undone\\.$/,"{delete_named_session_text}"],'
+        f'[/^[\\u201c\\"](.+?)[\\u201d\\"] will be permanently deleted\\. This can[\\u2019\\\']t be undone\\.$/,"{delete_named_session_text}"],'
         f'[/^Archive selected task\\?$/,"{archive_selected_tasks_text}"],'
         f'[/^Archive selected tasks\\?$/,"{archive_selected_tasks_text}"],'
         f'[/^(\\d+) tasks? will be moved to Archived\\.$/,"{archive_tasks_moved_text}"],'
-        '[/^Mon$/,"周一"],[/^Tue$/,"周二"],[/^Wed$/,"周三"],[/^Thu$/,"周四"],'
-        '[/^Fri$/,"周五"],[/^Sat$/,"周六"],[/^Sun$/,"周日"]'
     ))
+    greeting_rules = "".join((
+        f'[/^Morning, (.+)$/,"{morning_greeting}"],[/^Good morning, (.+)$/,"{morning_greeting}"],'
+        f'[/^Afternoon, (.+)$/,"{afternoon_greeting}"],[/^Good afternoon, (.+)$/,"{afternoon_greeting}"],'
+        f'[/^Evening, (.+)$/,"{evening_greeting}"],[/^Good evening, (.+)$/,"{evening_greeting}"],'
+        f"[/^It\\'s late-night (.+)$/,\"{late_night_greeting}\"],[/^Good night, (.+)$/,\"{good_night_greeting}\"],"
+        f'[/^Delete (\\d+) chat$/,"{delete_chat_text}"],[/^Delete (\\d+) chats$/,"{delete_chat_text}"],'
+        f'[/^Move (\\d+) chat to a project$/,"{move_chat_text}"],[/^Move (\\d+) chats to a project$/,"{move_chat_text}"],'
+        f'[/^Connection needs (\\d+) field$/,"{conn_needs_field_text}"],[/^Connection needs (\\d+) fields$/,"{conn_needs_field_text}"],'
+        f'[/^needs (\\d+) field$/,"{needs_field_text}"],[/^needs (\\d+) fields$/,"{needs_field_text}"],'
+        f'[/^Are you sure you want to delete (\\d+) chat\\? This cannot be undone\\.$/,"{delete_chat_confirm_text}"],'
+        f'[/^Are you sure you want to delete (\\d+) chats\\? This cannot be undone\\.$/,"{delete_chat_confirm_text}"],'
+        f'[/^Are you sure you want to permanently delete this chat\\? This cannot be undone\\.$/,"{delete_this_chat_confirm_text}"],'
+        f'[/^Are you sure you want to permanently delete these chats\\? This cannot be undone\\.$/,"{delete_these_chats_confirm_text}"],'
+        f'[/^Archive (\\d+) task\\? You can find it in the Archived tab\\.$/,"{archive_task_text}"],'
+        f'[/^Archive (\\d+) tasks\\? You can find them in the Archived tab\\.$/,"{archive_tasks_text}"],'
+    ))
+    wd = json.loads(weekday_labels)
+    weekday_rules = (
+        f'[/^Mon$/,"{wd[0]}"],[/^Tue$/,"{wd[1]}"],[/^Wed$/,"{wd[2]}"],[/^Thu$/,"{wd[3]}"],'
+        f'[/^Fri$/,"{wd[4]}"],[/^Sat$/,"{wd[5]}"],[/^Sun$/,"{wd[6]}"]'
+    )
     return (
         "(()=>{try{"
         f'const L="{lang_code}",M={mapping_json};'
         'localStorage.setItem("spa:locale",L);'
         'document.documentElement&&document.documentElement.setAttribute("lang",L);'
         'const N=s=>(s||"").replace(/\\s+/g," ").trim();'
-        'const G=[[/^Morning, (.+)$/,"早上好，$1"],[/^Good morning, (.+)$/,"早上好，$1"],'
-        '[/^Afternoon, (.+)$/,"下午好，$1"],[/^Good afternoon, (.+)$/,"下午好，$1"],'
-        '[/^Evening, (.+)$/,"晚上好，$1"],[/^Good evening, (.+)$/,"晚上好，$1"],'
-        '[/^It\\\'s late-night (.+)$/,"夜深了，$1"],[/^Good night, (.+)$/,"晚安，$1"],'
-        '[/^Delete (\\d+) chat$/,"删除 $1 个聊天"],[/^Delete (\\d+) chats$/,"删除 $1 个聊天"],'
-        '[/^Move (\\d+) chat to a project$/,"将 $1 个聊天移至项目"],[/^Move (\\d+) chats to a project$/,"将 $1 个聊天移至项目"],'
-        '[/^Connection needs (\\d+) field$/,"连接还需要填写 $1 个字段"],[/^Connection needs (\\d+) fields$/,"连接还需要填写 $1 个字段"],'
-        '[/^needs (\\d+) field$/,"还需要填写 $1 个字段"],[/^needs (\\d+) fields$/,"还需要填写 $1 个字段"],'
-        '[/^Are you sure you want to delete (\\d+) chat\\? This cannot be undone\\.$/,"你确定要删除 $1 个聊天吗？此操作无法撤消。"],'
-        '[/^Are you sure you want to delete (\\d+) chats\\? This cannot be undone\\.$/,"你确定要删除 $1 个聊天吗？此操作无法撤消。"],'
-        '[/^Are you sure you want to permanently delete this chat\\? This cannot be undone\\.$/,"你确定要永久删除此聊天吗？此操作无法撤消。"],'
-        '[/^Are you sure you want to permanently delete these chats\\? This cannot be undone\\.$/,"你确定要永久删除这些聊天吗？此操作无法撤消。"],'
-        '[/^Archive (\\d+) task\\? You can find it in the Archived tab\\.$/,"要归档 $1 个任务吗？你可以在“已归档”标签页中找到它。"],'
-        '[/^Archive (\\d+) tasks\\? You can find them in the Archived tab\\.$/,"要归档 $1 个任务吗？你可以在“已归档”标签页中找到它们。"],'
-        f'{dynamic_rules}];'
+        f'const G=[{greeting_rules}{dynamic_rules}{weekday_rules}];'
         'const R=s=>{const n=N(s);if(M[n])return M[n];for(const [r,t] of G){const m=n.match(r);'
         'if(m)return t.replace("$1",m[1])}};'
         'const X=new Set(["SCRIPT","STYLE","NOSCRIPT"]);'


### PR DESCRIPTION
## 概述

本次更新包含三部分内容：新增翻译条目、脚本多语言支持增强、繁体翻译质量修复。

## 变更详情

### 1. 新增翻译条目

**`resources/frontend-hardcoded-zh-HK.json` / `resources/frontend-hardcoded-zh-TW.json`**（各新增约 120 条）

涵盖以下新增界面文本：
- Cowork 管理面板：工作区限制、内建工具政策、停用内建工具、MCP 伺服器管理、组织插件等
- 诊断与更新：Anthropic 诊断资料、OpenTelemetry 收集器、阻止自动更新、自动更新强制时窗等
- 闸道与凭证：闸道基础 URL、闸道凭证、凭证类型、自订推理请求标头等
- 任务与归档：删除聊天确认对话框、归档任务确认、归档后提示、分类工作阶段状态等
- 扩充功能：浏览扩充功能、桌面扩充功能、要求扩充功能已签署等
- 其他：Claude Light/Dark 主题名、授权权杖、搜索设定、使用限制、输出要求等

**`resources/frontend-zh-HK.json` / `resources/frontend-zh-TW.json`**（各新增 4 条）

- `SBWkijOQlK` — "所有環境"
- `btDLI+exL1` — "暫無排程任務。"
- `bvhdbswdqH` — "按排程或在需要時執行任務。"
- `bw+L0wLpiO` — "設定一個持續工作的空間，讓上下文隨時間積累。"

### 2. 脚本多语言支持增强

**`scripts/install_windows.ps1`**

- DOM 翻译脚本从硬编码简体中文改为模板化替换，支持 zh-CN / zh-TW / zh-HK 三套独立翻译
- 新增以下动态翻译规则的多语言支持：
  - 时间段问候语（早上好/早安/早晨、下午好/午安、晚上好/晚安、夜深了、晚安）
  - 星期标签（周一~周日 / 週一~週日）
  - 删除聊天确认对话框（单数/复数形式）
  - 移动聊天至项目/专案
  - 连接需要填写字段提示
  - 归档任务确认提示
- 预清理逻辑 (`Invoke-PreInstallCleanup`) 从语言选择菜单前移至语言选定后执行，避免用户未确认选择就执行清理

**`scripts/patch_claude_zh_cn.py`**

- 将原本仅支持 zh-CN 的 DOM 动态翻译规则拆分为 zh-CN / zh-TW / zh-HK 三套独立规则
- 新增 `greeting_rules`（问候语）和 `weekday_rules`（星期标签）独立生成逻辑
- 新增以下动态翻译规则：删除聊天确认、移动聊天至项目/专案、连接需要填写字段、归档任务确认等
- 修复正则表达式中 Unicode 引号的转义写法（`['\"]` → `[“\"]`）

### 3. 繁体翻译质量修复

**修复简繁混用（zh-HK 和 zh-TW 各约 40+ 处）**

新增的翻译条目中存在大量简体字未转换为繁体字的问题，已全部修复：

| 简体（错误） | 繁体（修正后） | 示例上下文 |
|---|---|---|
| 会 | 會 | "分類工作階段~~会~~計入" → "會計入" |
| 计划 | 計劃 | "升級你的~~计划~~" → "計劃" |
| 吗 | 嗎 | "你確定要刪除…聊天~~吗~~？" → "嗎？" |
| 预 | 預 | "Artifact ~~预~~覽" → "預覽" |
| 给 | 給 | "傳送~~给~~ Anthropic" → "給" |
| 内 | 內 | "時長~~内~~" → "內"、"VM ~~内~~" → "內" |
| 装 | 裝 | "強制安~~装~~" → "安裝" |
| 员 | 員 | "管理~~员~~" → "員"、"支持人~~员~~" → "支援人員" |
| 电 | 電 | "使用者~~电~~腦" → "電腦" |
| 页 | 頁 | "登入~~页~~" → "頁" |
| 项 | 項 | "第一~~项~~" → "項"、"登入選~~项~~" → "選項" |
| 数 | 數 | "權杖~~数~~" → "數" |
| 论 | 論 | "評審評~~论~~" → "論" |
| 败 | 敗 | "CI 失~~败~~" → "敗" |
| 志 | 誌 | "日~~志~~" → "誌" |
| 么 | 麼 | "什~~么~~" → "麼" |
| 访 | 訪 | "可以~~访~~問" → "訪問" |
| 则 | 則 | "留空~~则~~" → "則"、"否~~则~~" → "則" |
| 于 | 於 | "適用~~于~~" → "於"、"基~~于~~" → "於" |
| 浅 | 淺 | "Claude ~~浅~~色" → "淺色" |
| 后 | 後 | "請求~~后~~" → "後"、"設定~~后~~" → "後" |
| 默认/默認 | 預設 | "~~默認~~為 72 小時" → "預設" |
| 自定义 | 自訂 | "~~自定义~~推理請求標頭" → "自訂" |

**修复 zh-TW "資訊夾" 错别字（2 处）**

- `title:"Allowed workspace folders"` 的翻译从 "允許的工作區**資訊夾**" 修正为 "允許的工作區**資料夾**"
- 新增条目 `"Allowed workspace folders"` 同上

> "資訊夾" 不是实际使用的中文词汇，正确应为 "資料夾"。

**修复 zh-TW 过度替换 "資料" → "資訊"（3 处）**

- "資**訊**分析" → "資**料**分析"（data analysis 应使用 "資料"）
- "中繼資**訊**" → "中繼資**料**"（metadata 的标准台湾繁体翻译为 "中繼資料"）
- "你的資**訊**絕不會傳送給" → "你的資**料**絕不會傳送給"（your data 对应 "資料"）

**统一 Archived 翻译**

- zh-HK 统一使用 "已封存"（香港惯用说法）
- zh-TW 统一使用 "已歸檔"（台湾惯用说法）

## Test plan

- [x] 验证 zh-HK/zh-TW hardcoded JSON 文件为合法 JSON 格式
- [x] 验证 zh-HK/zh-TW hardcoded 文件中不再包含简体字
- [x] 验证 zh-TW 中不再存在 "資訊夾" 错别字
- [x] 验证 zh-TW 中 "資料分析"、"中繼資料" 已恢复
- [ ] 在 Windows 上测试 `install_windows.ps1` 安装脚本的三种语言选项
- [ ] 在 macOS/Linux 上测试 `patch_claude_zh_cn.py` 的三种语言 DOM 翻译输出

🤖 Generated with [Claude Code](https://claude.com/claude-code)