### PR TITLE
[codex] Fix Windows interactive menu actions

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -126,9 +126,10 @@ Test-GitHubReleaseUpdate
 function Read-InteractiveSelection {
     Write-Host "=== Claude Desktop Windows 中文补丁 ==="
     Write-Host ""
-    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：（Cowork 沙箱/工作区不可用(看群公告))"
+    Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：Cowork 兼容)"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
+    Write-Host "[4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
     Write-Host "[Q] 退出"
     Write-Host ""


### PR DESCRIPTION
## Summary
- show the existing `[4]` auto-update action in the Windows interactive menu
- clarify that option `[1]` is the Cowork-compatible install mode

## Why
The prompt already accepts `[1/2/3/4/5/Q]` and the switch handles `[4]`, but the menu only displayed `[1]`, `[2]`, `[3]`, `[5]`, and `[Q]`. Option `[1]` also described Cowork as unavailable even though the safe install path is presented later as Cowork-compatible.

## Verification
- PowerShell AST parse for `scripts/install_windows.ps1`
- `git diff --check`