### PR TITLE
feat: 新增菜单选项 [6] 修复汉化后工作区（CoworkVMService）

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -2509,6 +2509,30 @@ function Set-ClaudeAutoUpdates {
     }
 }
 
+function Start-CoworkVMService {
+    $serviceName = "CoworkVMService"
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if (-not $service) {
+        Write-Host "  [提示] 未找到 $serviceName 服务，跳过。" -ForegroundColor DarkGray
+        return
+    }
+
+    if ($service.Status -eq "Running") {
+        Write-Host "  $serviceName 已在运行" -ForegroundColor Green
+        return
+    }
+
+    try {
+        Start-Service -Name $serviceName -ErrorAction Stop
+        Start-Sleep -Seconds 2
+        $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+        Write-Host "  $serviceName 已启动，当前状态: $($service.Status)" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [警告] 启动 $serviceName 失败: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+}
+
 function Repair-CoworkVMService {
     $serviceName = "CoworkVMService"
     $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$serviceName"
@@ -3165,6 +3189,9 @@ function Install-WindowsLanguagePack {
 
         Write-Step "重启 Claude Desktop"
         Restart-Claude $claudePath
+
+        Write-Step "启动 CoworkVMService"
+        Start-CoworkVMService
 
         Write-Host ""
         Write-Host "安装完成。如果界面未立即切换，请在 Language 中选择 $label。" -ForegroundColor Green

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -5,7 +5,7 @@
     [string]$PatchMode = "safe",
 
     [Parameter(Position = 0)]
-    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills")]
+    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills", "repair-cowork")]
     [string]$Action = "install",
 
     [Parameter(Position = 1)]
@@ -130,13 +130,14 @@ function Read-InteractiveSelection {
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
+    Write-Host "[6] 修复汉化后工作区（CoworkVMService）"
     Write-Host "[Q] 退出"
     Write-Host ""
 
     $patchModeForInstall = "safe"
     $actionSelected = $false
     while (-not $actionSelected) {
-        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/Q]").Trim()
+        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/6/Q]").Trim()
         switch -Regex ($actionSelection) {
             '^[1]$' { $patchModeForInstall = "safe"; $actionSelected = $true }
             '^[2]$' { $patchModeForInstall = "official"; $actionSelected = $true }
@@ -163,8 +164,9 @@ function Read-InteractiveSelection {
                     }
                 }
             }
+            '^[6]$' { return @{ Action = "repair-cowork"; Language = "zh-CN"; PatchMode = "safe" } }
             '^[Qq]$' { exit 0 }
-            default { Write-Host "请输入 1、2、3、4、5 或 Q。" -ForegroundColor Yellow }
+            default { Write-Host "请输入 1、2、3、4、5、6 或 Q。" -ForegroundColor Yellow }
         }
     }
 
@@ -2507,6 +2509,57 @@ function Set-ClaudeAutoUpdates {
     }
 }
 
+function Repair-CoworkVMService {
+    $serviceName = "CoworkVMService"
+    $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\$serviceName"
+
+    Write-Host "=== 修复 CoworkVMService 自动启动 ===" -ForegroundColor Cyan
+
+    # 检查服务是否存在
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if (-not $service) {
+        Write-Host "  [错误] 未找到 Windows 服务 $serviceName，请确认 Claude Desktop 已正确安装。" -ForegroundColor Red
+        return
+    }
+
+    Write-Host "  当前服务状态: $($service.Status)，启动类型: $($service.StartType)" -ForegroundColor DarkGray
+
+    # 写注册表，将 Start 设为 2（自动启动）
+    # Start 值含义: 2=自动, 3=手动, 4=禁用
+    try {
+        reg add "HKLM\SYSTEM\CurrentControlSet\Services\$serviceName" /v Start /t REG_DWORD /d 2 /f | Out-Null
+        Write-Host "  已将 $serviceName 启动类型设为自动启动 (Start=2)" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [错误] 写入注册表失败，需要管理员权限: $($_.Exception.Message)" -ForegroundColor Red
+        return
+    }
+
+    # 检查服务是否已在运行，未运行则启动
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+    if ($service.Status -ne "Running") {
+        Write-Host "  $serviceName 未在运行，正在启动..." -ForegroundColor DarkGray
+        try {
+            Start-Service -Name $serviceName -ErrorAction Stop
+            Start-Sleep -Seconds 2
+            $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+            Write-Host "  $serviceName 已启动，当前状态: $($service.Status)" -ForegroundColor Green
+        }
+        catch {
+            Write-Host "  [警告] 启动 $serviceName 失败: $($_.Exception.Message)" -ForegroundColor Yellow
+            Write-Host "  [提示] 启动类型已设为自动，下次系统启动时会自动运行。" -ForegroundColor DarkGray
+        }
+    }
+    else {
+        Write-Host "  $serviceName 已在运行" -ForegroundColor Green
+    }
+
+    Write-Host ""
+    Write-Host "修复完成。" -ForegroundColor Green
+    Write-Host "按任意键返回主菜单..." -ForegroundColor DarkGray
+    $null = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
+}
+
 function Get-CCSwitchSkillsDirectory {
     $userProfile = $env:USERPROFILE
     if (-not $userProfile) {
@@ -3224,6 +3277,7 @@ try {
         "enable-updates" { Set-ClaudeAutoUpdates $true }
         "sync-skills" { Sync-CCSwitchSkills }
         "unsync-skills" { Unsync-CCSwitchSkills }
+        "repair-cowork" { Repair-CoworkVMService }
     }
 
     Stop-InstallLog


### PR DESCRIPTION
## 变更内容

新增菜单选项 **[6] 修复汉化后工作区（CoworkVMService）**，用于修复汉化后 Cowork 工作区服务未自动启动的问题。

### 功能说明

1. **设置自动启动** — 通过写注册表将 CoworkVMService 的 Start 值设为 2（自动启动）
   - Start 值含义：2 = 自动，3 = 手动，4 = 禁用
   - 汉化过程中该值可能被意外修改，导致服务不自动启动

2. **立即启动服务** — 检查服务是否正在运行，未运行则启动它

3. **按任意键返回** — 操作完成后等待用户按键，再返回主菜单

### 实现细节

- 新增 Repair-CoworkVMService 函数
- param() 的 ValidateSet 新增 "repair-cowork" Action
- 主菜单 switch 新增 '6' 分支
- 需要管理员权限（修改 HKLM 注册表 + 控制 Windows 服务）
