### PR TITLE
feat(windows): 支持更新后自动重新应用汉化补丁

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
    - `3` 恢复原样 / 卸载补丁
    - `4` 自动更新设置（`y` 禁止自动更新，`n` 允许自动更新）
    - `5` 同步 CC Switch skills（`y` 开启同步，`n` 删除同步）
+   - `6` 更新后自动汉化（`y` 启用并安装，`n` 关闭；仅 Windows）
 5. 选择安装中文补丁时，脚本会先尝试从旧备份恢复来清理已有汉化；如果没有旧备份，会提示跳过并继续。
 6. 安装时再选择语言：
    - `1` 简体中文
@@ -77,12 +78,15 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
 7. 脚本会备份当前 Claude Desktop 资源，写入本仓库 `resources` 目录里的中文 JSON，补齐硬编码界面文本，并重启 Claude Desktop。选择模式 1 时会跳过 `app.asar` 补丁，更适合需要 Cowork/截图工作区的场景。选择模式 2 时会直接修改当前 Claude 的 `app.asar`，卸载时从备份恢复。
 8. 如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
 
+如果希望保留 Claude Desktop 自动更新，同时避免每次更新后手动重装中文补丁，请选择 `6`，再选择补丁模式和语言。启用后会创建 SYSTEM 计划任务，每 15 分钟检查一次 Claude 版本；检测到新版本后会等待一轮确认更新完成，并在 Claude Desktop/Cowork 未运行时静默重新应用补丁。选择 `6` 后输入 `n` 可关闭该功能，恢复/卸载补丁时也会自动清理计划任务和持久化文件。
+
 
 ## 文件说明
 
 - `install-mac.command`：macOS 双击运行入口。
 - `install-windows.bat`：Windows 安装 / 恢复菜单入口。
 - `scripts/install_windows.ps1`：Windows 汉化安装和卸载脚本。
+- `scripts/watch_claude_update.ps1`：Windows 更新后自动汉化检查脚本。
 - `scripts/patch_claude_zh_cn.py`：真正执行补丁的 Python 脚本。
 - `resources/manifest.json` / `manifest-zh-TW.json` / `manifest-zh-HK.json`：语言包信息。
 - `resources/frontend-zh-CN.json` / `frontend-zh-TW.json` / `frontend-zh-HK.json`：Claude 前端界面中文翻译。
@@ -125,6 +129,7 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
 - 写入 Windows 用户配置，将语言设置为所选语言代码（`zh-CN`、`zh-TW` 或 `zh-HK`）。
 - 可选菜单项 `4` 用 `y/n` 控制 Claude Desktop 自动更新：`y` 禁止自动更新，`n` 允许自动更新。若当前存在有效的 Claude-3p `configLibrary`，脚本会写入当前 applied 配置；否则写入 `HKCU\SOFTWARE\Policies\Claude` policy。
 - 可选菜单项 `5` 用 `y/n` 控制 CC Switch skills 同步：`y` 会把 `%USERPROFILE%\.cc-switch\skills` 中缺失的 skill 以软链接加入 Claude Desktop 的本地 skills 目录，并把 `SKILL.md` frontmatter 里的 `name` 和 `description` 写入对应 `manifest.json`；`n` 只删除之前同步产生、且指向 CC Switch skills 目录内的软链接和对应 manifest 记录。脚本会从当前用户的 AppData 动态扫描 Claude-3p skills plugin，不写死 session UUID，不覆盖同名 skill，也不删除 CC Switch 源目录。
+- 可选菜单项 `6` 用 `y/n` 控制更新后自动汉化：`y` 会按所选模式和语言立即安装补丁，将最小安装负载保存到 `%ProgramData%\ClaudeDesktopZhCn`，并注册 SYSTEM 计划任务；`n` 只移除计划任务和持久化负载，不改变当前中文界面。守护脚本不会关闭正在运行的 Claude，而是延后到应用退出后处理；新版本自动补丁失败时不会对同一版本无限重试，日志位于持久化目录。
 - 重启 Claude Desktop。
 
 ## 卸载 / 恢复
@@ -137,4 +142,4 @@ macOS 可双击 `install-mac.command`，Windows 可右键管理员运行 `instal
 
 ## 免责声明
 
-本项目为非官方中文补丁，仅修改本机 Claude Desktop 的本地资源文件。Claude Desktop 更新后资源结构可能变化，若补丁失败，请先更新本项目或重新运行安装脚本。
+本项目为非官方中文补丁，仅修改本机 Claude Desktop 的本地资源文件。Claude Desktop 更新后资源结构可能变化；即使启用了 Windows 更新后自动汉化，结构不兼容时仍可能失败。此时请先更新本项目，再重新启用更新后自动汉化。

--- a/scripts/auto_reapply_windows.ps1
+++ b/scripts/auto_reapply_windows.ps1
@@ -1,0 +1,176 @@
+﻿$script:AutoReapplyTaskName = "ClaudeDesktopZhCn-AutoReapply"
+
+function Get-AutoReapplyRoot {
+    $programData = [Environment]::GetFolderPath("CommonApplicationData")
+    if (-not $programData) {
+        throw "无法定位 ProgramData，不能配置更新后自动汉化。"
+    }
+    return Join-Path $programData "ClaudeDesktopZhCn"
+}
+
+function Remove-TreeWithoutFollowingLinks {
+    param([string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    if (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
+        if ($item.PSIsContainer) {
+            [System.IO.Directory]::Delete($Path, $false)
+        }
+        else {
+            [System.IO.File]::Delete($Path)
+        }
+        return
+    }
+    if ($item.PSIsContainer) {
+        foreach ($child in @(Get-ChildItem -LiteralPath $Path -Force -ErrorAction SilentlyContinue)) {
+            Remove-TreeWithoutFollowingLinks $child.FullName
+        }
+    }
+    Remove-Item -LiteralPath $Path -Force
+}
+
+function Remove-AutoReapplyRoot {
+    Remove-TreeWithoutFollowingLinks (Get-AutoReapplyRoot)
+}
+
+function Initialize-AutoReapplyRoot {
+    Remove-AutoReapplyRoot
+    $root = Get-AutoReapplyRoot
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+
+    $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $acl.SetAccessRuleProtection($true, $false)
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit"
+    $propagation = [System.Security.AccessControl.PropagationFlags]::None
+    foreach ($sid in @("S-1-5-18", "S-1-5-32-544")) {
+        $identity = [System.Security.Principal.SecurityIdentifier]::new($sid)
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $identity,
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            $inheritance,
+            $propagation,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        [void]$acl.AddAccessRule($rule)
+    }
+    Set-Acl -LiteralPath $root -AclObject $acl
+    return $root
+}
+
+function Get-ClaudeInstallIdentity {
+    param([string]$ClaudePath)
+
+    $fullPath = [System.IO.Path]::GetFullPath($ClaudePath).TrimEnd('\', '/').ToLowerInvariant()
+    $version = ""
+    $exe = Get-ClaudeExePath $ClaudePath
+    if ($exe) {
+        try {
+            $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($exe).ProductVersion
+        }
+        catch {
+            $version = ""
+        }
+    }
+    return "$fullPath|$version"
+}
+
+function Reset-AutoReapplyBackups {
+    $paths = Get-ClaudeResourcesPath
+    $resourcesPath = [string]$paths["Resources"]
+    $backupRoot = Get-BackupRoot $resourcesPath
+    if (Test-Path -LiteralPath $backupRoot) {
+        Write-Host "  检测到 Claude 新版本，丢弃旧版本补丁备份并建立新基线。" -ForegroundColor DarkGray
+        Remove-Item -LiteralPath $backupRoot -Recurse -Force
+    }
+    $script:CurrentBackupSetPath = $null
+}
+
+function Enable-AutoReapply {
+    $sourceRoot = Split-Path -Parent $PSScriptRoot
+    $sourceScripts = Join-Path $sourceRoot "scripts"
+    $sourceResources = Join-Path $sourceRoot "resources"
+    Require-File (Join-Path $sourceScripts "watch_claude_update.ps1")
+    Require-File (Join-Path $sourceScripts "install_windows.ps1")
+    Require-File (Join-Path $sourceResources "release.json")
+
+    Stop-ScheduledTask -TaskName $script:AutoReapplyTaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $script:AutoReapplyTaskName -Confirm:$false -ErrorAction SilentlyContinue
+    $root = Initialize-AutoReapplyRoot
+    $payloadRoot = Join-Path $root "payload"
+    $payloadScripts = Join-Path $payloadRoot "scripts"
+    $statePath = Join-Path $root "state.json"
+    New-Item -ItemType Directory -Path $payloadScripts -Force | Out-Null
+    foreach ($scriptName in @("install_windows.ps1", "auto_reapply_windows.ps1", "watch_claude_update.ps1")) {
+        Copy-Item -LiteralPath (Join-Path $sourceScripts $scriptName) -Destination $payloadScripts -Force
+    }
+    Copy-Item -LiteralPath $sourceResources -Destination $payloadRoot -Recurse -Force
+
+    $paths = Get-ClaudeResourcesPath
+    $identity = Get-ClaudeInstallIdentity ([string]$paths["App"])
+    $sid = [string]$env:CLAUDE_ZH_ORIGINAL_USER_SID
+    if (-not $sid) {
+        try { $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value } catch { $sid = "" }
+    }
+    $originalUserProfile = [string]$env:CLAUDE_ZH_ORIGINAL_USER_PROFILE
+    if (-not $originalUserProfile) { $originalUserProfile = [Environment]::GetFolderPath("UserProfile") }
+    $originalAppData = [string]$env:CLAUDE_ZH_ORIGINAL_APPDATA
+    if (-not $originalAppData) { $originalAppData = [string]$env:APPDATA }
+    $originalLocalAppData = [string]$env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA
+    if (-not $originalLocalAppData) { $originalLocalAppData = [Environment]::GetFolderPath("LocalApplicationData") }
+    $state = [pscustomobject]@{
+        schemaVersion = 1
+        language = $LanguageCode
+        patchMode = $PatchMode
+        lastPatchedIdentity = $identity
+        pendingIdentity = ""
+        failedIdentity = ""
+        originalUserSid = $sid
+        originalUserProfile = $originalUserProfile
+        originalAppData = $originalAppData
+        originalLocalAppData = $originalLocalAppData
+        configuredAt = (Get-Date).ToUniversalTime().ToString("o")
+    }
+    Save-JsonNoBom $statePath $state
+
+    $watcherPath = Join-Path $payloadRoot "scripts\watch_claude_update.ps1"
+    $taskArgument = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$watcherPath`" -StatePath `"$statePath`""
+    $taskAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument $taskArgument
+    $taskTrigger = New-ScheduledTaskTrigger `
+        -Once `
+        -At (Get-Date).AddMinutes(1) `
+        -RepetitionInterval (New-TimeSpan -Minutes 15) `
+        -RepetitionDuration (New-TimeSpan -Days 3650)
+    $taskTrigger.Repetition.StopAtDurationEnd = $false
+    $taskSettings = New-ScheduledTaskSettingsSet `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries `
+        -StartWhenAvailable `
+        -MultipleInstances IgnoreNew `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 20)
+    $taskPrincipal = New-ScheduledTaskPrincipal `
+        -UserId "SYSTEM" `
+        -LogonType ServiceAccount `
+        -RunLevel Highest
+
+    Register-ScheduledTask `
+        -TaskName $script:AutoReapplyTaskName `
+        -Action $taskAction `
+        -Trigger $taskTrigger `
+        -Settings $taskSettings `
+        -Principal $taskPrincipal `
+        -Description "Claude Desktop 更新后自动重新应用中文补丁" `
+        -Force | Out-Null
+
+    Write-Host "  已启用更新后自动汉化（每 15 分钟检查一次，Claude 运行时自动延后）。" -ForegroundColor Green
+    Write-Host "  持久化文件: $root" -ForegroundColor DarkGray
+}
+
+function Disable-AutoReapply {
+    Stop-ScheduledTask -TaskName $script:AutoReapplyTaskName -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName $script:AutoReapplyTaskName -Confirm:$false -ErrorAction SilentlyContinue
+    Remove-AutoReapplyRoot
+    Write-Host "  已关闭更新后自动汉化。当前已安装的中文补丁保持不变。" -ForegroundColor Green
+}

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,11 +1,12 @@
 ﻿param(
     [switch]$Interactive,
     [switch]$SkipAsarPatch,
+    [switch]$AutoReapply,
     [ValidateSet("safe", "official")]
     [string]$PatchMode = "safe",
 
     [Parameter(Position = 0)]
-    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills")]
+    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills", "enable-auto-reapply", "disable-auto-reapply")]
     [string]$Action = "install",
 
     [Parameter(Position = 1)]
@@ -39,6 +40,8 @@ if ($OriginalUserSid) { $env:CLAUDE_ZH_ORIGINAL_USER_SID = $OriginalUserSid }
 if ($OriginalUserProfile) { $env:CLAUDE_ZH_ORIGINAL_USER_PROFILE = $OriginalUserProfile }
 if ($OriginalAppData) { $env:CLAUDE_ZH_ORIGINAL_APPDATA = $OriginalAppData }
 if ($OriginalLocalAppData) { $env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA = $OriginalLocalAppData }
+
+. (Join-Path $PSScriptRoot "auto_reapply_windows.ps1")
 
 function Start-InstallLog {
     try {
@@ -90,7 +93,7 @@ function Test-SkipReleaseUpdateCheck {
 }
 
 function Test-GitHubReleaseUpdate {
-    if (Test-SkipReleaseUpdateCheck) {
+    if ($AutoReapply -or (Test-SkipReleaseUpdateCheck)) {
         return
     }
 
@@ -129,14 +132,17 @@ function Read-InteractiveSelection {
     Write-Host "[1] 安装中文补丁(第三方API登陆模式(例DeepSeek)：（Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[2] 安装中文补丁(官方账号登录模式：Cowork 沙箱/工作区不可用(看群公告))"
     Write-Host "[3] 恢复原样 / 卸载补丁"
+    Write-Host "[4] Claude Desktop 自动更新设置"
     Write-Host "[5] 同步 CC Switch skills（y=开启同步，n=删除同步）"
+    Write-Host "[6] 更新后自动汉化（y=启用并安装，n=关闭）"
     Write-Host "[Q] 退出"
     Write-Host ""
 
     $patchModeForInstall = "safe"
+    $installAction = "install"
     $actionSelected = $false
     while (-not $actionSelected) {
-        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/Q]").Trim()
+        $actionSelection = (Read-Host "请选择操作 [1/2/3/4/5/6/Q]").Trim()
         switch -Regex ($actionSelection) {
             '^[1]$' { $patchModeForInstall = "safe"; $actionSelected = $true }
             '^[2]$' { $patchModeForInstall = "official"; $actionSelected = $true }
@@ -163,8 +169,31 @@ function Read-InteractiveSelection {
                     }
                 }
             }
+            '^[6]$' {
+                $autoChoice = (Read-Host "是否启用更新后自动汉化？[y=启用并安装 / n=关闭]").Trim()
+                switch -Regex ($autoChoice) {
+                    '^[Nn]$' { return @{ Action = "disable-auto-reapply"; Language = "zh-CN"; PatchMode = "safe" } }
+                    '^[Yy]$' {
+                        $modeChoice = (Read-Host "请选择自动汉化模式 [1=Cowork 兼容 / 2=官方账号，默认 1]").Trim()
+                        switch -Regex ($modeChoice) {
+                            '^$|^[1]$' { $patchModeForInstall = "safe" }
+                            '^[2]$' { $patchModeForInstall = "official" }
+                            default {
+                                Write-Host "无效输入，请输入 1 或 2。" -ForegroundColor Yellow
+                                continue
+                            }
+                        }
+                        $installAction = "enable-auto-reapply"
+                        $actionSelected = $true
+                    }
+                    default {
+                        Write-Host "无效输入，请输入 y 启用，或输入 n 关闭。" -ForegroundColor Yellow
+                        continue
+                    }
+                }
+            }
             '^[Qq]$' { exit 0 }
-            default { Write-Host "请输入 1、2、3、4、5 或 Q。" -ForegroundColor Yellow }
+            default { Write-Host "请输入 1、2、3、4、5、6 或 Q。" -ForegroundColor Yellow }
         }
     }
 
@@ -181,9 +210,9 @@ function Read-InteractiveSelection {
     while ($true) {
         $languageSelection = (Read-Host "请选择语言 [1/2/3/Q]").Trim()
         switch -Regex ($languageSelection) {
-            '^[1]$' { return @{ Action = "install"; Language = "zh-CN"; PatchMode = $patchModeForInstall } }
-            '^[2]$' { return @{ Action = "install"; Language = "zh-TW"; PatchMode = $patchModeForInstall } }
-            '^[3]$' { return @{ Action = "install"; Language = "zh-HK"; PatchMode = $patchModeForInstall } }
+            '^[1]$' { return @{ Action = $installAction; Language = "zh-CN"; PatchMode = $patchModeForInstall } }
+            '^[2]$' { return @{ Action = $installAction; Language = "zh-TW"; PatchMode = $patchModeForInstall } }
+            '^[3]$' { return @{ Action = $installAction; Language = "zh-HK"; PatchMode = $patchModeForInstall } }
             '^[Qq]$' { exit 0 }
             default { Write-Host "请输入 1、2、3 或 Q。" -ForegroundColor Yellow }
         }
@@ -230,7 +259,10 @@ function Format-ByteSize {
 }
 
 function Get-UnpackagedClaudePaths {
-    $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+    $localAppData = [string]$env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA
+    if (-not $localAppData) {
+        $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
+    }
     if (-not $localAppData) {
         return @()
     }
@@ -3294,18 +3326,28 @@ function Install-WindowsLanguagePack {
 
     # 单实例互斥锁：防止多个安装进程并发写入 app.asar
     $mutex = New-Object System.Threading.Mutex($false, "Global\ClaudeDesktopZhCn-Installer")
+    $mutexAcquired = $false
     try {
         if (-not $mutex.WaitOne(0)) {
-            Write-Host "  [错误] 另一个安装进程正在运行，请等待其完成后再试。" -ForegroundColor Red
-            return
+            throw "另一个安装进程正在运行，请等待其完成后再试。"
         }
+        $mutexAcquired = $true
     } catch [System.Threading.AbandonedMutexException] {
         # 上一个进程异常退出，锁已释放，继续执行
+        $mutexAcquired = $true
     }
 
     Write-Host "=== Claude Desktop Windows $label 补丁 ===" -ForegroundColor Cyan
 
     try {
+        if ($AutoReapply) {
+            $running = @((Get-ClaudeDesktopProcesses) + (Get-ClaudeCoworkProcesses))
+            if ($running.Count -gt 0) {
+                throw "Claude Desktop 或 Cowork 正在运行，自动汉化已延后。"
+            }
+            Reset-AutoReapplyBackups
+        }
+
         Write-Step "[1/8] 检查安装模式"
         if ($PatchMode -eq "safe") {
             Write-Host "  Cowork 兼容模式。" -ForegroundColor Green
@@ -3316,8 +3358,10 @@ function Install-WindowsLanguagePack {
         Write-Step "[2/8] 检查语言资源"
         $pack = Get-LanguageResources $LanguageCode
 
-        Write-Step "关闭 Claude Desktop"
-        Stop-ClaudeProcesses
+        if (-not $AutoReapply) {
+            Write-Step "关闭 Claude Desktop"
+            Stop-ClaudeProcesses
+        }
 
         Write-Step "[3/8] 查找 Claude Desktop"
         $paths = Get-ClaudeResourcesPath
@@ -3357,11 +3401,13 @@ function Install-WindowsLanguagePack {
         Write-Step "[8/8] 写入用户语言配置"
         Set-ClaudeLocale $LanguageCode
 
-        Write-Step "重启 Claude Desktop"
-        Restart-Claude $claudePath
+        if (-not $AutoReapply) {
+            Write-Step "重启 Claude Desktop"
+            Restart-Claude $claudePath
 
-        Write-Step "启动 CoworkVMService"
-        Start-CoworkVMService
+            Write-Step "启动 CoworkVMService"
+            Start-CoworkVMService
+        }
 
         Write-Host ""
         Write-Host "安装完成。如果界面未立即切换，请在 Language 中选择 $label。" -ForegroundColor Green
@@ -3377,7 +3423,9 @@ function Install-WindowsLanguagePack {
         throw
     }
     finally {
-        $mutex.ReleaseMutex()
+        if ($mutexAcquired) {
+            $mutex.ReleaseMutex()
+        }
         $mutex.Dispose()
     }
 }
@@ -3466,14 +3514,25 @@ $LanguageCode = $Language
 try {
     switch ($Action) {
         "install" {
-            Invoke-PreInstallCleanup
+            if (-not $AutoReapply) {
+                Invoke-PreInstallCleanup
+            }
             Install-WindowsLanguagePack
         }
-        "uninstall" { Uninstall-WindowsLanguagePack }
+        "uninstall" {
+            Disable-AutoReapply
+            Uninstall-WindowsLanguagePack
+        }
         "disable-updates" { Set-ClaudeAutoUpdates $false }
         "enable-updates" { Set-ClaudeAutoUpdates $true }
         "sync-skills" { Sync-CCSwitchSkills }
         "unsync-skills" { Unsync-CCSwitchSkills }
+        "enable-auto-reapply" {
+            Invoke-PreInstallCleanup
+            Install-WindowsLanguagePack
+            Enable-AutoReapply
+        }
+        "disable-auto-reapply" { Disable-AutoReapply }
     }
 
     Stop-InstallLog

--- a/scripts/tests/watch_claude_update.Tests.ps1
+++ b/scripts/tests/watch_claude_update.Tests.ps1
@@ -1,0 +1,98 @@
+﻿$ErrorActionPreference = "Stop"
+$Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+$Watcher = (Resolve-Path (Join-Path $PSScriptRoot "..\watch_claude_update.ps1")).Path
+$TempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("claude-zh-watcher-test-" + [guid]::NewGuid().ToString("N"))
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Message)
+    if ($Actual -ne $Expected) {
+        throw "$Message (expected=$Expected, actual=$Actual)"
+    }
+}
+
+function Invoke-Watcher {
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $Watcher -StatePath $script:StatePath
+    return $LASTEXITCODE
+}
+
+function New-FakeClaudeVersion {
+    param([string]$Name)
+    $app = Join-Path $script:LocalAppData "AnthropicClaude\$Name"
+    New-Item -ItemType Directory -Path (Join-Path $app "resources") -Force | Out-Null
+    [System.IO.File]::WriteAllText((Join-Path $app "Claude.exe"), $Name, $Utf8NoBom)
+    (Get-Item -LiteralPath $app).LastWriteTime = Get-Date
+    return $app
+}
+
+try {
+    $LocalAppData = Join-Path $TempRoot "LocalAppData"
+    $PayloadScripts = Join-Path $TempRoot "payload\scripts"
+    $StatePath = Join-Path $TempRoot "state.json"
+    New-Item -ItemType Directory -Path $PayloadScripts -Force | Out-Null
+    [void](New-FakeClaudeVersion "app-1.0.0")
+
+    $fakeInstaller = @'
+param(
+    [string]$Action,
+    [string]$Language,
+    [string]$PatchMode,
+    [switch]$AutoReapply,
+    [string]$OriginalUserSid,
+    [string]$OriginalUserProfile,
+    [string]$OriginalAppData,
+    [string]$OriginalLocalAppData
+)
+$root = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Add-Content -LiteralPath (Join-Path $root "fake-installer-runs.log") -Value $Language
+if (Test-Path -LiteralPath (Join-Path $root "fail.flag")) { exit 7 }
+exit 0
+'@
+    [System.IO.File]::WriteAllText((Join-Path $PayloadScripts "install_windows.ps1"), $fakeInstaller, $Utf8NoBom)
+
+    $state = [pscustomobject]@{
+        schemaVersion = 1
+        language = "zh-CN"
+        patchMode = "safe"
+        lastPatchedIdentity = "old-version"
+        pendingIdentity = ""
+        failedIdentity = ""
+        originalUserSid = "S-1-5-21-test"
+        originalUserProfile = Join-Path $TempRoot "User"
+        originalAppData = Join-Path $TempRoot "AppData"
+        originalLocalAppData = $LocalAppData
+    }
+    [System.IO.File]::WriteAllText($StatePath, ($state | ConvertTo-Json), $Utf8NoBom)
+
+    Assert-Equal (Invoke-Watcher) 0 "首次发现版本变化应只记录 pending"
+    $pendingState = Get-Content -LiteralPath $StatePath -Raw | ConvertFrom-Json
+    if (-not $pendingState.pendingIdentity) { throw "首次检查没有记录 pendingIdentity" }
+    if (Test-Path -LiteralPath (Join-Path $TempRoot "fake-installer-runs.log")) { throw "首次检查不应立即执行补丁" }
+    $expectedIdentity = $pendingState.pendingIdentity
+
+    Assert-Equal (Invoke-Watcher) 0 "第二次确认稳定版本后应执行补丁"
+    $patchedState = Get-Content -LiteralPath $StatePath -Raw | ConvertFrom-Json
+    Assert-Equal $patchedState.lastPatchedIdentity $expectedIdentity "成功后应记录已补丁版本"
+    Assert-Equal $patchedState.pendingIdentity "" "成功后应清空 pendingIdentity"
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $TempRoot "fake-installer-runs.log")).Count 1 "成功路径应执行一次安装器"
+    Assert-Equal (Invoke-Watcher) 0 "已汉化版本应直接跳过"
+    Assert-Equal (Get-Content -LiteralPath (Join-Path $TempRoot "fake-installer-runs.log")).Count 1 "已汉化版本不应重复执行安装器"
+
+    Start-Sleep -Milliseconds 20
+    [void](New-FakeClaudeVersion "app-2.0.0")
+    [System.IO.File]::WriteAllText((Join-Path $TempRoot "fail.flag"), "fail", $Utf8NoBom)
+    Assert-Equal (Invoke-Watcher) 0 "新版本首次检查仍应等待稳定"
+    Assert-Equal (Invoke-Watcher) 7 "安装器失败码应向外传递"
+    $failedState = Get-Content -LiteralPath $StatePath -Raw | ConvertFrom-Json
+    if (-not $failedState.failedIdentity) { throw "失败后没有记录 failedIdentity" }
+    $runCountAfterFailure = @(Get-Content -LiteralPath (Join-Path $TempRoot "fake-installer-runs.log")).Count
+
+    Assert-Equal (Invoke-Watcher) 0 "同一失败版本后续检查应安全跳过"
+    Assert-Equal @(Get-Content -LiteralPath (Join-Path $TempRoot "fake-installer-runs.log")).Count $runCountAfterFailure "同一失败版本不应无限重试"
+
+    Write-Host "watch_claude_update.Tests.ps1: PASS" -ForegroundColor Green
+}
+finally {
+    if ((Test-Path -LiteralPath $TempRoot) -and $TempRoot.StartsWith([System.IO.Path]::GetTempPath(), [System.StringComparison]::OrdinalIgnoreCase)) {
+        Remove-Item -LiteralPath $TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/watch_claude_update.ps1
+++ b/scripts/watch_claude_update.ps1
@@ -1,0 +1,230 @@
+﻿param(
+    [Parameter(Mandatory = $true)]
+    [string]$StatePath
+)
+
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+
+function Write-WatcherLog {
+    param([string]$Message)
+
+    try {
+        $root = Split-Path -Parent $StatePath
+        New-Item -ItemType Directory -Path $root -Force | Out-Null
+        $logPath = Join-Path $root "update-watcher.log"
+        if ((Test-Path -LiteralPath $logPath) -and (Get-Item -LiteralPath $logPath).Length -gt 1MB) {
+            $tail = @(Get-Content -LiteralPath $logPath -Tail 200 -ErrorAction SilentlyContinue)
+            [System.IO.File]::WriteAllLines($logPath, $tail, $Utf8NoBom)
+        }
+        $line = "[{0}] {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Message
+        [System.IO.File]::AppendAllText($logPath, "$line`r`n", $Utf8NoBom)
+    }
+    catch {
+    }
+}
+
+function Save-State {
+    param([pscustomobject]$State)
+
+    $json = $State | ConvertTo-Json -Depth 10
+    $tempPath = "$StatePath.tmp"
+    [System.IO.File]::WriteAllText($tempPath, $json, $Utf8NoBom)
+    Move-Item -LiteralPath $tempPath -Destination $StatePath -Force
+}
+
+function Set-StateProperty {
+    param(
+        [pscustomobject]$State,
+        [string]$Name,
+        [object]$Value
+    )
+    $State | Add-Member -NotePropertyName $Name -NotePropertyValue $Value -Force
+}
+
+function Get-ClaudeExePath {
+    param([string]$ClaudePath)
+
+    foreach ($candidate in @(
+        (Join-Path $ClaudePath "Claude.exe"),
+        (Join-Path $ClaudePath "claude.exe"),
+        (Join-Path $ClaudePath "app\Claude.exe"),
+        (Join-Path $ClaudePath "app\claude.exe")
+    )) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $candidate
+        }
+    }
+    return $null
+}
+
+function Get-ClaudeInstallIdentity {
+    param([string]$ClaudePath)
+
+    $fullPath = [System.IO.Path]::GetFullPath($ClaudePath).TrimEnd('\', '/').ToLowerInvariant()
+    $version = ""
+    $exe = Get-ClaudeExePath $ClaudePath
+    if ($exe) {
+        try {
+            $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($exe).ProductVersion
+        }
+        catch {
+            $version = ""
+        }
+    }
+    return "$fullPath|$version"
+}
+
+function Get-ClaudeInstallInfo {
+    param([pscustomobject]$State)
+
+    $localAppData = [string]$State.originalLocalAppData
+    if ($localAppData) {
+        $unpackagedBase = Join-Path $localAppData "AnthropicClaude"
+        $latest = Get-ChildItem -LiteralPath $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "resources") -PathType Container } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+        if ($latest) {
+            return [pscustomobject]@{
+                appPath = $latest.FullName
+                identity = Get-ClaudeInstallIdentity $latest.FullName
+            }
+        }
+    }
+
+    $package = Get-AppxPackage -AllUsers -Name "Claude" -ErrorAction SilentlyContinue |
+        Where-Object { $_.InstallLocation -and (Test-Path -LiteralPath $_.InstallLocation) } |
+        Sort-Object Version -Descending |
+        Select-Object -First 1
+    if ($package) {
+        $resourcesPath = Join-Path $package.InstallLocation "app\resources"
+        if (Test-Path -LiteralPath $resourcesPath -PathType Container) {
+            return [pscustomobject]@{
+                appPath = $package.InstallLocation
+                identity = Get-ClaudeInstallIdentity $package.InstallLocation
+            }
+        }
+    }
+
+    $fallback = Get-ChildItem "C:\Program Files\WindowsApps\Claude_*" -Directory -ErrorAction SilentlyContinue |
+        Where-Object { Test-Path -LiteralPath (Join-Path $_.FullName "app\resources") -PathType Container } |
+        Sort-Object LastWriteTime -Descending |
+        Select-Object -First 1
+    if ($fallback) {
+        return [pscustomobject]@{
+            appPath = $fallback.FullName
+            identity = Get-ClaudeInstallIdentity $fallback.FullName
+        }
+    }
+    return $null
+}
+
+function Test-ClaudeIsRunning {
+    param([string]$ClaudePath)
+
+    $appRoot = [System.IO.Path]::GetFullPath($ClaudePath).TrimEnd('\', '/')
+    foreach ($process in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)) {
+        if ($process.Name -notin @("claude.exe", "cowork-svc.exe")) {
+            continue
+        }
+        $executablePath = [string]$process.ExecutablePath
+        if (-not $executablePath) {
+            continue
+        }
+        try {
+            $fullPath = [System.IO.Path]::GetFullPath($executablePath)
+            if ($fullPath.StartsWith($appRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $true
+            }
+        }
+        catch {
+        }
+    }
+    return $false
+}
+
+try {
+    if (-not (Test-Path -LiteralPath $StatePath -PathType Leaf)) {
+        exit 0
+    }
+    $state = Get-Content -LiteralPath $StatePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if ($state.schemaVersion -ne 1 -or $state.language -notin @("zh-CN", "zh-TW", "zh-HK") -or $state.patchMode -notin @("safe", "official")) {
+        Write-WatcherLog "状态文件无效，停止检查。"
+        exit 1
+    }
+
+    $install = Get-ClaudeInstallInfo $state
+    if (-not $install) {
+        Write-WatcherLog "未找到完整的 Claude Desktop 安装，等待下次检查。"
+        exit 0
+    }
+    if ($install.identity -eq [string]$state.lastPatchedIdentity) {
+        exit 0
+    }
+    if ($install.identity -eq [string]$state.failedIdentity) {
+        exit 0
+    }
+
+    if ($install.identity -ne [string]$state.pendingIdentity) {
+        Set-StateProperty $state "pendingIdentity" $install.identity
+        Set-StateProperty $state "pendingSince" (Get-Date).ToUniversalTime().ToString("o")
+        Set-StateProperty $state "failedIdentity" ""
+        Save-State $state
+        Write-WatcherLog "检测到 Claude Desktop 新版本，等待下一轮确认更新已稳定: $($install.identity)"
+        exit 0
+    }
+
+    if (Test-ClaudeIsRunning $install.appPath) {
+        Write-WatcherLog "Claude Desktop/Cowork 正在运行，本轮延后自动汉化。"
+        exit 0
+    }
+
+    $payloadRoot = Join-Path (Split-Path -Parent $StatePath) "payload"
+    $installer = Join-Path $payloadRoot "scripts\install_windows.ps1"
+    if (-not (Test-Path -LiteralPath $installer -PathType Leaf)) {
+        throw "持久化安装脚本不存在: $installer"
+    }
+
+    $arguments = @(
+        "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass",
+        "-File", $installer,
+        "-Action", "install",
+        "-Language", [string]$state.language,
+        "-PatchMode", [string]$state.patchMode,
+        "-AutoReapply"
+    )
+    foreach ($item in @(
+        @("-OriginalUserSid", [string]$state.originalUserSid),
+        @("-OriginalUserProfile", [string]$state.originalUserProfile),
+        @("-OriginalAppData", [string]$state.originalAppData),
+        @("-OriginalLocalAppData", [string]$state.originalLocalAppData)
+    )) {
+        if ($item[1]) {
+            $arguments += $item
+        }
+    }
+    & powershell.exe @arguments
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+        Set-StateProperty $state "failedIdentity" $install.identity
+        Set-StateProperty $state "pendingIdentity" ""
+        Save-State $state
+        Write-WatcherLog "自动汉化失败（退出码 $exitCode）。为保护当前版本，本版本不再自动重试；请查看 payload\install-windows.log。"
+        exit $exitCode
+    }
+
+    Set-StateProperty $state "lastPatchedIdentity" $install.identity
+    Set-StateProperty $state "pendingIdentity" ""
+    Set-StateProperty $state "pendingSince" ""
+    Set-StateProperty $state "failedIdentity" ""
+    Set-StateProperty $state "lastPatchedAt" (Get-Date).ToUniversalTime().ToString("o")
+    Save-State $state
+    Write-WatcherLog "Claude Desktop 新版本已自动汉化: $($install.identity)"
+    exit 0
+}
+catch {
+    Write-WatcherLog "自动检查失败: $($_.Exception.Message)"
+    exit 1
+}


### PR DESCRIPTION
## 背景

Claude Desktop 更新会替换安装目录，现有中文资源随之丢失，用户需要再次手动运行安装程序。历史 PR #64 曾加入 Windows 更新守护，但后来被移除；旧方案依赖临时脚本路径和“低权限任务再创建高权限任务”，也没有隔离旧版本备份。

## 改动

- 新增菜单项 `6`，由用户明确选择启用或关闭“更新后自动汉化”，不默认安装后台任务
- 启用时按所选模式/语言立即安装，并将最小负载持久化到受保护的 `%ProgramData%\ClaudeDesktopZhCn`
- 注册 SYSTEM 计划任务，每 15 分钟检测 Claude 安装标识变化
- 连续两轮发现同一新版本后才处理；Claude/Cowork 运行中则延后，不主动关闭用户会话
- 新版本重打补丁前丢弃旧版本备份，再以新版原始文件建立可卸载基线
- 同一版本补丁失败后停止自动重试，避免反复修改不兼容版本；日志保留在持久化目录
- 关闭功能或卸载补丁时清理计划任务和持久化负载

## 安全与兼容性

- 计划任务负载目录仅授权 SYSTEM 和 Administrators
- 清理旧目录时不跟随 junction/符号链接，防止预创建目录带来的提权风险
- 保留原用户 SID/Profile/AppData，使 SYSTEM 任务仍写入正确用户的 Claude 配置
- 仅覆盖 Windows；macOS 需要 root LaunchDaemon，未在无法真实验证的情况下混入本 PR

## 测试

- Windows PowerShell AST 语法解析：4 个脚本通过
- `scripts/tests/watch_claude_update.Tests.ps1`：版本待确认、成功、幂等、失败停止重试均通过
- 实际构造 ScheduledTask trigger/settings/SYSTEM principal 通过
- junction 清理回归：链接本身被删除，链接外目标保持不变
- `git diff --check` 通过

关联 #48。