### PR TITLE
fix: 优化 Patch-HardcodedFrontendStrings 避免长时间卡住

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1750,13 +1750,18 @@ function Patch-HardcodedFrontendStrings {
     $replacements = @(Get-FrontendHardcodedReplacements $Language)
     $patchedFiles = 0
     $patchedStrings = 0
+    $fileIndex = 0
     foreach ($file in $jsFiles) {
+        $fileIndex += 1
         $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
         $patched = $text
         $count = 0
         foreach ($pair in $replacements) {
             $source = $pair[0]
             $target = $pair[1]
+            if (-not $patched.Contains($source)) {
+                continue
+            }
             $result = Replace-FrontendHardcodedText $patched $source $target
             if ($result["Count"] -gt 0) {
                 $patched = $result["Text"]
@@ -1769,6 +1774,9 @@ function Patch-HardcodedFrontendStrings {
             [System.IO.File]::WriteAllText($file.FullName, $patched, $Utf8NoBom)
             $patchedFiles += 1
             $patchedStrings += $count
+            Write-Host "  patched file $fileIndex/$($jsFiles.Count): $($file.Name) ($count replacements)" -ForegroundColor DarkGray
+        } else {
+            Write-Host "  skipping file $fileIndex/$($jsFiles.Count): $($file.Name) (no matches)" -ForegroundColor DarkGray
         }
     }
 


### PR DESCRIPTION
## 问题

安装汉化时在 `[7/8] 汉化硬编码界面文本` 步骤长时间卡住（超过数分钟无输出）。

## 原因

`Patch-HardcodedFrontendStrings` 对 600+ 个 JS bundle 文件逐一执行 543 个替换项，每次都调用 `Replace-FrontendHardcodedText`（含正则编译），即使源字符串根本不在该文件中。总迭代约 32 万次，导致严重卡顿。

## 修复

- 在调用替换函数前加 `$patched.Contains($source)` 快速过滤，跳过不包含源字符串的文件
- 新增逐文件进度日志（`patched file 1/600: xxx.js`），方便用户观察执行进展
