### PR TITLE
fix(windows): select valid Claude app by version

### DIFF
--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -230,6 +230,30 @@ function Format-ByteSize {
     return "$Bytes bytes"
 }
 
+function Get-UnpackagedClaudeVersion {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    if ($Directory.Name -notmatch '^app-(\d+(?:\.\d+){1,3})$') {
+        return $null
+    }
+
+    try {
+        return [version]$matches[1]
+    }
+    catch {
+        return $null
+    }
+}
+
+function Test-UnpackagedClaudeAppDirectory {
+    param([System.IO.DirectoryInfo]$Directory)
+
+    $version = Get-UnpackagedClaudeVersion $Directory
+    return ($null -ne $version) -and
+        (Test-Path -LiteralPath (Join-Path $Directory.FullName "Claude.exe")) -and
+        (Test-Path -LiteralPath (Join-Path $Directory.FullName "resources"))
+}
+
 function Get-UnpackagedClaudePaths {
     $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
     if (-not $localAppData) {
@@ -242,7 +266,10 @@ function Get-UnpackagedClaudePaths {
     }
 
     return @(Get-ChildItem $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime -Descending |
+        Where-Object { Test-UnpackagedClaudeAppDirectory $_ } |
+        Sort-Object `
+            @{ Expression = { Get-UnpackagedClaudeVersion $_ }; Descending = $true },
+            @{ Expression = { $_.LastWriteTime }; Descending = $true } |
         ForEach-Object { $_.FullName })
 }
 


### PR DESCRIPTION
## Summary

- reject unpackaged `app-*` candidates whose directory names are not valid numeric versions
- require both `Claude.exe` and `resources` before treating a directory as an installed Claude Desktop version
- select the highest valid app version, using `LastWriteTime` only as a tie-breaker

## Root cause

Squirrel updates can leave multiple `app-*` directories behind. The previous implementation sorted only by directory modification time, so a stale, incomplete, or backup-like directory could be selected instead of the active Claude Desktop installation.

## Impact

Windows install, restore, and maintenance actions now target the highest valid Claude Desktop version instead of relying on filesystem timestamps.

This supersedes #103 with stricter rejection of non-version directory names and is refreshed onto the current `main` branch.

## Verification

- PowerShell 5.1 AST parse
- PowerShell 7 AST parse
- synthetic multi-directory smoke test covering valid, incomplete, and non-version candidates
- multi-version selection smoke test
- `git diff --check`
