### PR TITLE
修复更新后汉化丢失与新版本兼容失败,并增加上游发版预警

### DIFF
--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -1,0 +1,58 @@
+name: Sync to Gitee mirror
+
+# 将 main 分支与 tag 自动同步到 Gitee 镜像仓库,供国内用户直连下载。
+#
+# 启用步骤(维护者):
+#   1. 在 Gitee 创建同名仓库(可为空仓库);
+#   2. 在 Gitee「设置 → 私人令牌」生成具有 projects 权限的 token;
+#   3. 在本仓库 GitHub「Settings → Secrets and variables → Actions」添加:
+#      - Secret  GITEE_TOKEN     : 上一步生成的 Gitee 私人令牌
+#      - Variable GITEE_REPO     : Gitee 仓库路径,如 javaht/claude-desktop-zh-cn
+#      - Variable GITEE_USERNAME : Gitee 登录用户名
+#   未配置时本 workflow 自动跳过,不报错。
+
+on:
+  push:
+    branches: [main]
+    tags: ["*"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-gitee
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
+      GITEE_REPO: ${{ vars.GITEE_REPO }}
+      GITEE_USERNAME: ${{ vars.GITEE_USERNAME }}
+    steps:
+      - name: Check configuration
+        id: config
+        run: |
+          if [ -n "$GITEE_TOKEN" ] && [ -n "$GITEE_REPO" ] && [ -n "$GITEE_USERNAME" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "Gitee 镜像未配置(缺 GITEE_TOKEN / GITEE_REPO / GITEE_USERNAME),跳过同步。" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.config.outputs.configured == 'true'
+        with:
+          fetch-depth: 0
+
+      - name: Push main and tags to Gitee
+        if: steps.config.outputs.configured == 'true'
+        run: |
+          set -euo pipefail
+          git remote add gitee "https://${GITEE_USERNAME}:${GITEE_TOKEN}@gitee.com/${GITEE_REPO}.git"
+          git push --force gitee "refs/remotes/origin/main:refs/heads/main"
+          git push --force gitee --tags
+          echo "已同步 main 与全部 tag 到 gitee.com/${GITEE_REPO}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,7 +160,10 @@ jobs:
             throw "fallback guard did not throw"
           }
           catch {
-            if ($_.Exception.Message -notmatch "不会继续基础模式") { throw }
+            # Match the ASCII error code, not the Chinese text: the runner may
+            # hand the inline script to Windows PowerShell 5.1 without a BOM,
+            # and mojibake in the pattern would make this rethrow forever.
+            if ($_.Exception.Message -notmatch "fullmode-halt") { throw }
           }
           if ($script:fallbackCalls -ne 1) { throw "fallback ran after an unconfirmed rollback" }
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,7 +227,9 @@ jobs:
             throw "resumable pending restore did not complete"
           }
           $afterResume = [IO.File]::ReadAllText((Join-Path $resumeAssets "app-HASH.js"))
-          if ($afterResume -ne $originalBundle) {
+          # Set-Content appended a trailing newline when the fixture was written,
+          # so compare ignoring it; the restored bytes come from that same fixture.
+          if ($afterResume.TrimEnd("`r", "`n") -ne $originalBundle) {
             throw "resumable restore did not keep the original frontend bundle"
           }
           if (Test-Path -LiteralPath (Get-WindowsPendingRestorePath $resumeFixture)) {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,7 @@ jobs:
           $rollbackRoot = Join-Path $fixture ".zh-cn-backups\fixture-rollback"
           New-Item -ItemType Directory -Path $rollbackRoot -Force | Out-Null
           Set-Content -LiteralPath (Join-Path $rollbackRoot "original.bin") -Encoding ASCII -Value "keep-me"
+          $realRestoreBackupSet = ${function:Restore-BackupSet}
           function Restore-BackupSet { throw "injected restore failure" }
           $script:InstallTransactionActive = $true
           $script:InstallTransactionResourcesPath = $fixture
@@ -168,6 +169,7 @@ jobs:
           if ($script:fallbackCalls -ne 1) { throw "fallback ran after an unconfirmed rollback" }
 
           # Resumable exact restore: half-restored tree + pending state must continue the same backup.
+          Set-Item function:Restore-BackupSet $realRestoreBackupSet
           $resumeApp = Join-Path $env:RUNNER_TEMP "claude-zh-resume"
           $resumeFixture = Join-Path $resumeApp "resources"
           $resumeAssets = Join-Path $resumeFixture "ion-dist\assets\v2"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,10 @@ jobs:
             patchedFingerprint = Get-WindowsMaintenanceFingerprint $paths
           }
           $marker = $marker | ConvertTo-Json -Depth 30 | ConvertFrom-Json
+          # Test-WindowsPatchCurrent requires the marker's backup set to exist.
+          $backupBundle = Join-Path $fixture ".zh-cn-backups\fixture\ion-dist\assets\v2\app-HASH.js"
+          New-Item -ItemType Directory -Path (Split-Path -Parent $backupBundle) -Force | Out-Null
+          Set-Content -LiteralPath $backupBundle -Encoding UTF8 -Value $source
           if (-not (Test-WindowsPatchCurrent $marker $paths "zh-CN" "safe")) {
             throw "complete marker was not accepted"
           }
@@ -110,9 +114,6 @@ jobs:
             throw "missing locale invalidated the exact official backup baseline"
           }
 
-          $backupBundle = Join-Path $fixture ".zh-cn-backups\fixture\ion-dist\assets\v2\app-HASH.js"
-          New-Item -ItemType Directory -Path (Split-Path -Parent $backupBundle) -Force | Out-Null
-          Set-Content -LiteralPath $backupBundle -Encoding UTF8 -Value $source
           Save-JsonNoBom (Get-PatchMarkerPath $fixture) $marker 30
           function Get-ClaudeResourcesPath { return $paths }
           function Stop-ClaudeProcesses {}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,247 @@
+name: Test patch compatibility
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Compile Python scripts
+        run: python -m py_compile scripts/patch_claude_zh_cn.py scripts/macos_auto_repair.py
+      - name: Run fixture tests
+        run: python -m unittest discover -s tests -v
+
+  powershell:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Parse Windows installer with Windows PowerShell 5.1
+        shell: powershell
+        run: |
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path "scripts/install_windows.ps1"),
+            [ref]$null,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | Format-List -Force
+            exit 1
+          }
+      - name: Test Windows dynamic layout and locale registration
+        shell: powershell
+        run: |
+          . .\scripts\install_windows.ps1 -LibraryMode
+          $appRoot = Join-Path $env:RUNNER_TEMP "claude-zh-layout"
+          $fixture = Join-Path $appRoot "resources"
+          $assets = Join-Path $fixture "ion-dist\assets\v2"
+          $locales = Join-Path $fixture "ion-dist\locales"
+          New-Item -ItemType Directory -Path $assets, $locales -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $appRoot "Claude.exe") -Encoding ASCII -Value "fixture-exe"
+          Set-Content -LiteralPath (Join-Path $fixture "app.asar") -Encoding ASCII -Value "fixture-asar"
+          Set-Content -LiteralPath (Join-Path $assets "app-HASH.js") -Encoding UTF8 -Value `
+            "const languageOptions=['fr-FR','en-US','nl-NL','de-DE','ja-JP','ko-KR','id-ID'];"
+          Set-Content -LiteralPath (Join-Path $locales "en-US.json") -Encoding UTF8 -Value '{"hello":"Hello"}'
+
+          $files = @(Get-FrontendJavaScriptFiles $fixture)
+          if ($files.Count -ne 1 -or $files[0].Name -ne "app-HASH.js") { throw "dynamic assets discovery failed" }
+          if ((Get-FrontendI18nDirectory $fixture) -ne $locales) { throw "dynamic i18n discovery failed" }
+
+          $source = [IO.File]::ReadAllText($files[0].FullName)
+          $first = Update-LanguageArraysInText $source "zh-CN"
+          if ($first.ChangedCount -ne 1 -or -not $first.Text.Contains("'nl-NL'") -or -not $first.Text.Contains("'zh-CN'")) {
+            throw "semantic locale append failed"
+          }
+          $second = Update-LanguageArraysInText $first.Text "zh-CN"
+          if ($second.ChangedCount -ne 0 -or $second.AlreadyCount -lt 1) { throw "locale append is not idempotent" }
+
+          Set-Content -LiteralPath $files[0].FullName -Encoding UTF8 -Value ($first.Text + ";/*__claudeZhLabelPatch*/")
+          Set-Content -LiteralPath (Join-Path $locales "zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          New-Item -ItemType Directory -Path (Join-Path $locales "statsig") -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $locales "statsig\zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          Set-Content -LiteralPath (Join-Path $fixture "zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          $paths = @{ App = $appRoot; Resources = $fixture; InstallKind = "Fixture" }
+          $frontendBundleFiles = @("ion-dist\assets\v2\app-HASH.js")
+          $localeResourceFiles = @(
+            "ion-dist\locales\zh-CN.json",
+            "ion-dist\locales\statsig\zh-CN.json",
+            "zh-CN.json"
+          )
+          $marker = [ordered]@{
+            schemaVersion = 2
+            patchVersion = Get-PatchReleaseVersion
+            language = "zh-CN"
+            mode = "safe"
+            backupSet = "fixture"
+            createdFiles = @(
+              $localeResourceFiles
+            )
+            frontendBundleFiles = $frontendBundleFiles
+            frontendBundleFingerprints = @(Get-RelativeFileFingerprints $fixture $frontendBundleFiles)
+            localeResourceFingerprints = @(Get-RelativeFileFingerprints $fixture $localeResourceFiles)
+            modifiedResourceFingerprints = @(Get-RelativeFileFingerprints $fixture $frontendBundleFiles)
+            appIdentity = Get-ClaudeAppIdentity $paths
+            patchedFingerprint = Get-WindowsMaintenanceFingerprint $paths
+          }
+          $marker = $marker | ConvertTo-Json -Depth 30 | ConvertFrom-Json
+          if (-not (Test-WindowsPatchCurrent $marker $paths "zh-CN" "safe")) {
+            throw "complete marker was not accepted"
+          }
+          Remove-Item -LiteralPath (Join-Path $locales "zh-CN.json") -Force
+          if (Test-WindowsPatchCurrent $marker $paths "zh-CN" "safe") {
+            throw "marker without locale was incorrectly accepted"
+          }
+          if (-not (Test-PatchMarkerMatchesIdentity $marker $paths) -or
+              -not (Test-PatchMarkerMatchesFingerprint $marker $paths)) {
+            throw "missing locale invalidated the exact official backup baseline"
+          }
+
+          $backupBundle = Join-Path $fixture ".zh-cn-backups\fixture\ion-dist\assets\v2\app-HASH.js"
+          New-Item -ItemType Directory -Path (Split-Path -Parent $backupBundle) -Force | Out-Null
+          Set-Content -LiteralPath $backupBundle -Encoding UTF8 -Value $source
+          Save-JsonNoBom (Get-PatchMarkerPath $fixture) $marker 30
+          function Get-ClaudeResourcesPath { return $paths }
+          function Stop-ClaudeProcesses {}
+          function Remove-LegacyAppxForkArtifacts {}
+          if (-not (Uninstall-WindowsLanguagePack -ForReinstall)) {
+            throw "exact partial marker baseline was not restored"
+          }
+          $restoredSource = [IO.File]::ReadAllText($files[0].FullName)
+          if ($restoredSource.Contains("zh-CN") -or $restoredSource.Contains("__claudeZhLabelPatch")) {
+            throw "partial repair did not restore the original frontend bundle"
+          }
+          if (Test-Path -LiteralPath (Get-BackupRoot $fixture)) {
+            throw "restored backup set was not cleaned up"
+          }
+
+          $rollbackRoot = Join-Path $fixture ".zh-cn-backups\fixture-rollback"
+          New-Item -ItemType Directory -Path $rollbackRoot -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $rollbackRoot "original.bin") -Encoding ASCII -Value "keep-me"
+          function Restore-BackupSet { throw "injected restore failure" }
+          $script:InstallTransactionActive = $true
+          $script:InstallTransactionResourcesPath = $fixture
+          $script:CurrentBackupSetPath = $rollbackRoot
+          $script:InstallTransactionCreatedFiles = [System.Collections.Generic.List[string]]::new()
+          $rollbackResult = Rollback-InstallTransaction $fixture
+          if ($rollbackResult -or -not (Test-Path -LiteralPath $rollbackRoot)) {
+            throw "failed rollback did not preserve its backup"
+          }
+          $script:InstallTransactionActive = $true
+          $script:InstallTransactionResourcesPath = $fixture
+          $script:CurrentBackupSetPath = Join-Path $fixture ".zh-cn-backups\missing"
+          $script:InstallTransactionCreatedFiles = [System.Collections.Generic.List[string]]::new()
+          if (Rollback-InstallTransaction $fixture) {
+            throw "missing backup set was incorrectly treated as a successful rollback"
+          }
+
+          $script:PatchMode = "official"
+          $script:fallbackCalls = 0
+          function Install-WindowsLanguagePack {
+            $script:fallbackCalls += 1
+            throw "injected full-mode failure"
+          }
+          try {
+            [void](Install-WindowsLanguagePackWithFallback)
+            throw "fallback guard did not throw"
+          }
+          catch {
+            if ($_.Exception.Message -notmatch "不会继续基础模式") { throw }
+          }
+          if ($script:fallbackCalls -ne 1) { throw "fallback ran after an unconfirmed rollback" }
+
+          # Resumable exact restore: half-restored tree + pending state must continue the same backup.
+          $resumeApp = Join-Path $env:RUNNER_TEMP "claude-zh-resume"
+          $resumeFixture = Join-Path $resumeApp "resources"
+          $resumeAssets = Join-Path $resumeFixture "ion-dist\assets\v2"
+          $resumeLocales = Join-Path $resumeFixture "ion-dist\locales"
+          New-Item -ItemType Directory -Path $resumeAssets, $resumeLocales, (Join-Path $resumeLocales "statsig") -Force | Out-Null
+          Set-Content -LiteralPath (Join-Path $resumeApp "Claude.exe") -Encoding ASCII -Value "resume-exe"
+          Set-Content -LiteralPath (Join-Path $resumeFixture "app.asar") -Encoding ASCII -Value "resume-asar"
+          $originalBundle = "const languageOptions=['fr-FR','en-US','nl-NL','de-DE','ja-JP','ko-KR','id-ID'];"
+          $patchedBundle = $originalBundle + "/*__claudeZhLabelPatch*/;const languageOptions=['fr-FR','en-US','nl-NL','de-DE','ja-JP','ko-KR','id-ID','zh-CN'];"
+          Set-Content -LiteralPath (Join-Path $resumeAssets "app-HASH.js") -Encoding UTF8 -Value $patchedBundle
+          Set-Content -LiteralPath (Join-Path $resumeLocales "en-US.json") -Encoding UTF8 -Value '{"hello":"Hello"}'
+          Set-Content -LiteralPath (Join-Path $resumeLocales "zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          Set-Content -LiteralPath (Join-Path $resumeLocales "statsig\zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          Set-Content -LiteralPath (Join-Path $resumeFixture "zh-CN.json") -Encoding UTF8 -Value '{"hello":"你好"}'
+          $resumePaths = @{ App = $resumeApp; Resources = $resumeFixture; InstallKind = "Fixture" }
+          $resumeBundleRel = "ion-dist\assets\v2\app-HASH.js"
+          $resumeLocaleRels = @(
+            "ion-dist\locales\zh-CN.json",
+            "ion-dist\locales\statsig\zh-CN.json",
+            "zh-CN.json"
+          )
+          $backupBundle = Join-Path $resumeFixture ".zh-cn-backups\resume-set\$resumeBundleRel"
+          New-Item -ItemType Directory -Path (Split-Path -Parent $backupBundle) -Force | Out-Null
+          Set-Content -LiteralPath $backupBundle -Encoding UTF8 -Value $originalBundle
+          $resumeMarker = [ordered]@{
+            schemaVersion = 2
+            patchVersion = Get-PatchReleaseVersion
+            language = "zh-CN"
+            mode = "safe"
+            backupSet = "resume-set"
+            createdFiles = @($resumeLocaleRels)
+            frontendBundleFiles = @($resumeBundleRel)
+            frontendBundleFingerprints = @(Get-RelativeFileFingerprints $resumeFixture @($resumeBundleRel))
+            localeResourceFingerprints = @(Get-RelativeFileFingerprints $resumeFixture $resumeLocaleRels)
+            modifiedResourceFingerprints = @(Get-RelativeFileFingerprints $resumeFixture @($resumeBundleRel))
+            appIdentity = Get-ClaudeAppIdentity $resumePaths
+            patchedFingerprint = Get-WindowsMaintenanceFingerprint $resumePaths
+          }
+          $resumeMarker = $resumeMarker | ConvertTo-Json -Depth 30 | ConvertFrom-Json
+          Save-JsonNoBom (Get-PatchMarkerPath $resumeFixture) $resumeMarker 30
+          # Simulate crash mid-restore: original bundle already restored, locale still present, pending state written.
+          Set-Content -LiteralPath (Join-Path $resumeAssets "app-HASH.js") -Encoding UTF8 -Value $originalBundle
+          Write-WindowsPendingRestore $resumeFixture $resumeMarker $resumePaths
+          if (-not (Test-Path -LiteralPath (Get-WindowsPendingRestorePath $resumeFixture))) {
+            throw "pending restore state was not written"
+          }
+          if (Test-PatchMarkerMatchesFingerprint $resumeMarker $resumePaths) {
+            throw "half-restored tree still matched patched fingerprint"
+          }
+          function Get-ClaudeResourcesPath { return $resumePaths }
+          function Stop-ClaudeProcesses {}
+          function Remove-LegacyAppxForkArtifacts {}
+          function Set-ClaudeLocale { param([string]$Locale) }
+          if (-not (Uninstall-WindowsLanguagePack -ForReinstall)) {
+            throw "resumable pending restore did not complete"
+          }
+          $afterResume = [IO.File]::ReadAllText((Join-Path $resumeAssets "app-HASH.js"))
+          if ($afterResume -ne $originalBundle) {
+            throw "resumable restore did not keep the original frontend bundle"
+          }
+          if (Test-Path -LiteralPath (Get-WindowsPendingRestorePath $resumeFixture)) {
+            throw "pending restore state was not cleared after success"
+          }
+          if (Test-Path -LiteralPath (Get-PatchMarkerPath $resumeFixture)) {
+            throw "marker remained after resumable restore"
+          }
+          if (Test-Path -LiteralPath (Get-BackupRoot $resumeFixture)) {
+            throw "backup set remained after resumable restore"
+          }
+          foreach ($localeRel in $resumeLocaleRels) {
+            if (Test-Path -LiteralPath (Join-Path $resumeFixture $localeRel)) {
+              throw "patch-created locale remained after resumable restore: $localeRel"
+            }
+          }
+
+  shell:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate macOS entrypoint
+        run: bash -n install-mac.command

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -1,0 +1,175 @@
+name: Upstream compatibility watch
+
+# 监控 Claude Desktop 官方更新源:新版本发布后数小时内自动下载并做兼容性
+# 检测(--doctor + 完整 dry-run),失败或"完整模式静默降级为安全模式"时自动
+# 开 issue——把"客户端更新打破汉化"的发现时间从"用户报 issue 后数天"压缩到
+# "官方发版当天"。
+#
+# 仅在 macOS 上检测:前端资源与 asar 锚点两端同构,macOS 检测失败即预示
+# Windows 同样受影响;Windows 专属逻辑由 test.yml 的 fixture 测试覆盖。
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: upstream-watch
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Query official update feed
+        id: feed
+        run: |
+          set -euo pipefail
+          DEVICE_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+          FEED=$(curl -fsS --retry 3 --retry-all-errors --retry-delay 10 --max-time 30 \
+            "https://api.anthropic.com/api/desktop/darwin/universal/squirrel/update?device_id=${DEVICE_ID}")
+          VERSION=$(printf '%s' "$FEED" | python3 -c 'import json,sys; print(json.load(sys.stdin)["currentRelease"])')
+          URL=$(printf '%s' "$FEED" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["releases"][0]["updateTo"]["url"])')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "url=${URL}" >> "$GITHUB_OUTPUT"
+          echo "Latest upstream release: ${VERSION}"
+
+      - name: Skip if this version was already reported
+        id: dedupe
+        env:
+          UPSTREAM_VERSION: ${{ steps.feed.outputs.version }}
+        run: |
+          set -euo pipefail
+          # 前缀匹配同时覆盖“检测失败”与“降级”两种标题;--state all 保证
+          # issue 被关闭后同版本不会在下个周期重复开出。
+          PREFIX="[upstream-watch] Claude ${UPSTREAM_VERSION}"
+          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --state all \
+            --search "\"$PREFIX\" in:title" --json number --jq 'length')
+          echo "already-reported=$([ "$EXISTING" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Download and extract Claude.app
+        if: steps.dedupe.outputs.already-reported == 'false'
+        env:
+          UPSTREAM_URL: ${{ steps.feed.outputs.url }}
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 3 --retry-all-errors --retry-delay 10 --retry-max-time 900 \
+            --max-time 600 -o claude-upstream.zip "$UPSTREAM_URL"
+          mkdir -p extracted
+          ditto -x -k claude-upstream.zip extracted/
+          APP=$(find extracted -maxdepth 3 -name "Claude.app" -type d | head -1)
+          test -n "$APP" || { echo "Claude.app not found in the archive"; exit 1; }
+          echo "CLAUDE_APP=$APP" >> "$GITHUB_ENV"
+
+      - name: Doctor compatibility report
+        if: steps.dedupe.outputs.already-reported == 'false'
+        id: doctor
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          python3 scripts/patch_claude_zh_cn.py --app "$CLAUDE_APP" --doctor --json | tee doctor.json
+
+      - name: Full dry-run patch
+        if: steps.dedupe.outputs.already-reported == 'false'
+        id: dryrun
+        continue-on-error: true
+        run: |
+          python3 scripts/patch_claude_zh_cn.py --app "$CLAUDE_APP" --user-home "$HOME" --dry-run 2>&1 | tee dryrun.log
+          rc="${PIPESTATUS[0]}"
+          # 安装器对最终用户"降级到安全模式继续装"是正确行为,但对监控是漏报:
+          # asar 锚点失效恰是最该报警的场景,这里把静默降级转为独立失败信号。
+          if [ "$rc" -eq 0 ] && grep -q "Compatibility fallback succeeded" dryrun.log; then
+            echo "degraded=true" >> "$GITHUB_OUTPUT"
+            exit 3
+          fi
+          echo "degraded=false" >> "$GITHUB_OUTPUT"
+          exit "$rc"
+
+      - name: Check for silent full-mode degradation
+        if: >-
+          steps.dedupe.outputs.already-reported == 'false' &&
+          steps.doctor.outcome == 'success' && steps.dryrun.outcome == 'success'
+        id: fullcheck
+        run: |
+          set -euo pipefail
+          if python3 -c 'import json,sys; sys.exit(0 if json.load(open("doctor.json")).get("fullCompatible") else 1)'; then
+            echo "degraded=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "degraded=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issue on failure or degradation
+        if: >-
+          steps.dedupe.outputs.already-reported == 'false' &&
+          (steps.doctor.outcome == 'failure' ||
+           steps.dryrun.outcome == 'failure' ||
+           steps.fullcheck.outputs.degraded == 'true')
+        env:
+          UPSTREAM_VERSION: ${{ steps.feed.outputs.version }}
+          UPSTREAM_URL: ${{ steps.feed.outputs.url }}
+          DOCTOR_OUTCOME: ${{ steps.doctor.outcome }}
+          DRYRUN_OUTCOME: ${{ steps.dryrun.outcome }}
+          DRYRUN_DEGRADED: ${{ steps.dryrun.outputs.degraded }}
+          FULLCHECK_DEGRADED: ${{ steps.fullcheck.outputs.degraded }}
+        run: |
+          set -euo pipefail
+          DEGRADED=false
+          [ "$DRYRUN_DEGRADED" = "true" ] && DEGRADED=true
+          [ "$FULLCHECK_DEGRADED" = "true" ] && DEGRADED=true
+          if [ "$DOCTOR_OUTCOME" = "failure" ] || { [ "$DRYRUN_OUTCOME" = "failure" ] && [ "$DEGRADED" != "true" ]; }; then
+            TITLE="[upstream-watch] Claude ${UPSTREAM_VERSION} 兼容性检测失败"
+            LEVEL="基础汉化安装失败,需要尽快适配。"
+          else
+            TITLE="[upstream-watch] Claude ${UPSTREAM_VERSION} 完整模式降级为安全模式"
+            LEVEL="基础汉化仍可安装,但 app.asar 增强补丁(在线页面翻译/菜单等)的锚点已失效,自动降级为安全模式。"
+          fi
+          {
+            echo "官方更新源发布了 Claude Desktop **${UPSTREAM_VERSION}**,自动兼容性检测结果:${LEVEL}"
+            echo
+            echo "- \`--doctor\`: **${DOCTOR_OUTCOME}**"
+            echo "- 完整 dry-run: **${DRYRUN_OUTCOME}**(降级: ${DEGRADED})"
+            echo "- 安装包: ${UPSTREAM_URL}"
+            echo
+            echo "<details><summary>doctor.json</summary>"
+            echo
+            echo '```json'
+            cat doctor.json 2>/dev/null || echo "(doctor 无输出)"
+            echo '```'
+            echo "</details>"
+            echo
+            echo "<details><summary>dry-run 日志(末尾 100 行)</summary>"
+            echo
+            echo '```'
+            tail -100 dryrun.log 2>/dev/null || echo "(dry-run 无输出)"
+            echo '```'
+            echo "</details>"
+          } > issue-body.md
+          gh label create upstream-watch --repo "$GITHUB_REPOSITORY" \
+            --description "自动上游兼容性检测" --color D93F0B --force
+          gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+            --body-file issue-body.md --label "upstream-watch"
+
+      - name: Summary
+        if: always()
+        env:
+          UPSTREAM_VERSION: ${{ steps.feed.outputs.version }}
+        run: |
+          {
+            echo "## Upstream watch: Claude ${UPSTREAM_VERSION}"
+            if [ "${{ steps.dedupe.outputs.already-reported }}" = "true" ]; then
+              echo "该版本已有检测报告(含已关闭的),跳过本轮检测。"
+            else
+              echo "- doctor: ${{ steps.doctor.outcome }}"
+              echo "- dry-run: ${{ steps.dryrun.outcome }}"
+              echo "- 完整模式降级: ${{ steps.fullcheck.outputs.degraded || steps.dryrun.outputs.degraded }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ macOS 双击 `install-mac.command`；Windows 双击 `install-windows.bat` 后按
 
 ## 使用方式
 
+### 国内用户下载
+
+无法顺畅访问 GitHub 时,可用以下方式获取本项目(安装器的新版检测已内置 jsDelivr 回退,无需翻墙也能收到更新提醒):
+
+1. **Gitee 镜像**(若维护者已启用):`https://gitee.com/<镜像地址>`,克隆或下载 zip 与 GitHub 相同。
+2. **公共加速站**:在 GitHub 下载链接前加上加速前缀,例如:
+   ```text
+   https://ghfast.top/https://github.com/javaht/claude-desktop-zh-cn/archive/refs/heads/main.zip
+   ```
+   同类站点还有 `gh-proxy.com` 等,失效时可自行搜索「GitHub 加速」替换前缀。
+   > ⚠️ 加速站是第三方中转,理论上存在内容被篡改的风险。本项目的安装脚本会以管理员权限运行,请尽量优先使用直连或 Gitee 镜像;使用加速站下载后,建议与群内发布的文件比对大小/哈希。
+3. **用户群**:关注群公告发布的安装包(见项目主页)。
+
 ### macOS
 
 1. 退出 Claude Desktop。
@@ -101,7 +114,8 @@ macOS 可先做只读兼容诊断：
 - `resources/desktop-zh-CN.json` / `desktop-zh-TW.json` / `desktop-zh-HK.json`：Claude 桌面壳层中文翻译。
 - `resources/Localizable.strings` / `Localizable-zh-TW.strings` / `Localizable-zh-HK.strings`：macOS 原生菜单中文资源。
 - `resources/statsig-zh-CN.json` / `statsig-zh-TW.json` / `statsig-zh-HK.json`：statsig i18n 兜底资源。
-- `resources/release.json`：安装入口用于检查 GitHub Releases 是否有新版的版本信息。
+- `resources/release.json`：安装入口用于检查是否有新版的版本信息(GitHub API 不可达时自动回退 jsDelivr)。
+- `.github/workflows/sync-gitee.yml`：GitHub → Gitee 镜像自动同步(维护者按文件内注释配置 `GITEE_TOKEN` 等后生效,未配置时自动跳过)。
 
 ## macOS 脚本会做什么
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ macOS 双击 `install-mac.command`；Windows 双击 `install-windows.bat` 后按
 ## 功能特点
 
 - 一键安装 Claude Desktop 中文界面资源，支持 macOS 和 Windows。
+- 安装后启用受保护的自动修复服务：Claude Desktop 更新覆盖资源后，自动识别新版本并重新应用已选择的语言和模式。
 - 支持三种中文变体：`zh-CN`（简体中文）、`zh-TW`（繁体中文（中国台湾））、`zh-HK`（繁体中文（中国香港））。
-- 自动给 Claude 前端语言白名单加入当前选择的中文变体。
+- 按语义定位前端资源和语言白名单，不再依赖固定的 `assets/v1` 目录或完整语言数组；保留新版新增的所有内置语言。
 - 完整/官方账号模式会修改 `app.asar`，对在线账号登录后的 `claude.ai` 页面做显示层 DOM 翻译；该逻辑只改界面文本和语言状态，不改第三方 API、网关、模型路由或请求内容。
 - macOS 会合并当前 Claude 版本的英文语言文件与随包中文翻译；新版本新增但暂未翻译的字段保留英文，避免界面缺失文本。
 - macOS 完整补丁模式可绕过新版 Claude Desktop 对第三方网关模型名的本地 Anthropic 校验，避免 `deepseek-v4-pro` / `kimi-*` 等模型名导致配置整体失效；跳过结构性 `app.asar` 的模式不包含此功能。
 - Windows 安装脚本会备份并修改当前 Claude Desktop 的资源文件，卸载时从备份恢复。需要 Cowork 沙箱或截图工作区时应选择 Windows 模式 1。
 - macOS 安装前自动备份原始 `/Applications/Claude.app`。
+- 备份恢复会核对 Claude build 和原始 `app.asar` 指纹；更新后的新版绝不会被旧备份降级覆盖，安装提交失败也会自动回滚原版。
 - 自动写入 Claude 用户配置，将语言设置为所选中文变体。
 
 ## 适用环境
@@ -42,13 +44,13 @@ macOS 双击 `install-mac.command`；Windows 双击 `install-windows.bat` 后按
 2. 下载或克隆本项目。
 3. 双击 `install-mac.command`，选择操作：
    - `1` 完整补丁：支持官方账号和第三方 API；会修改 `app.asar`，包含在线页面 DOM 汉化、在线语言锁定、第三方模型名校验绕过和 `app.asar` 内模型选择器汉化。此模式不适合依赖 Cowork 沙箱/工作区的场景。
-   - `2` 跳过结构性 `app.asar` 补丁：仍会安装中文资源、注册中文语言、汉化前端 bundle，并对少量主进程菜单做等长替换；不会注入在线页面 DOM 汉化，不会绕过第三方模型名校验，也不会修改 `app.asar` 内模型选择器。此模式仍会对应用做本机 ad-hoc 重签名，不承诺 Cowork 可用。
+   - `2` 基础兼容模式：安装中文资源、注册中文语言并汉化前端 bundle，完全不读写 `app.asar`；不会注入在线页面 DOM 汉化、主进程菜单或模型校验绕过。此模式仍会对应用做本机 ad-hoc 重签名，不承诺 Cowork 可用。
    - `3` 恢复原样 / 卸载补丁。
    - `4` 自动更新设置：输入 `y` 禁止自动更新，输入 `n` 允许自动更新。
    - `5` CC Switch skills 同步：输入 `y` 同步，输入 `n` 删除之前的同步。
-4. 选择安装后，脚本会先恢复已有旧备份以清理上一轮补丁；没有旧备份时会直接继续。
+4. 选择安装后，脚本只会恢复与当前已打补丁 build 和源指纹完全匹配的备份；检测到官方新版时保留新版并丢弃不兼容旧备份。
 5. 选择语言：`1`=简体中文，`2`=繁体中文（中国台湾），`3`=繁体中文（中国香港）。
-6. 按提示输入 Mac 登录密码。安装完成后 Claude 会自动重新打开。
+6. 按提示输入 Mac 登录密码。安装完成后 Claude 会自动重新打开，并安装 root 所有、普通用户不可修改的更新自动修复服务。
 7. 如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
 
 CC Switch skills 同步会扫描 `~/.cc-switch/skills` 下包含 `SKILL.md` 的目录，只为 Claude Desktop 中不存在的同名 skill 创建软链接并更新 skills manifest。取消同步只删除由该目录同步出的软链接和对应记录，不删除 CC Switch 源目录。
@@ -64,9 +66,26 @@ CC Switch skills 同步会扫描 `~/.cc-switch/skills` 下包含 `SKILL.md` 的�
    - `3` 恢复原样 / 卸载补丁。
    - `4` 自动更新设置：输入 `y` 禁止自动更新，输入 `n` 允许自动更新。
    - `5` CC Switch skills 同步：输入 `y` 开启同步，输入 `n` 删除之前的同步。
-5. 选择安装中文补丁时，脚本会先尝试从旧备份恢复来清理已有汉化；如果没有旧备份，会提示跳过并继续。
+5. 选择安装中文补丁时，脚本只会恢复带本项目 marker 的当前版本备份；官方更新后的新版本不会回灌旧文件。
 6. 选择语言：`1`=简体中文，`2`=繁体中文（中国台湾），`3`=繁体中文（中国香港）。
-7. 脚本会备份被修改的文件、写入中文资源并重启 Claude Desktop。如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
+7. 脚本会备份被修改的文件、写入中文资源、重启 Claude Desktop，并注册管理员保护目录中的自动修复计划任务。如果没有自动切换，打开左下角账号菜单，选择 `Language` -> 对应的中文选项。
+
+## 更新后自动恢复与新版兼容
+
+- 自动修复只运行本次安装时复制的脚本和语言资源，不会以 root/SYSTEM 身份从网络下载或执行新代码。
+- macOS payload 位于 `/Library/Application Support/ClaudeDesktopZhCN`，由 LaunchDaemon 每 5 分钟检查一次；Windows payload 位于 `%ProgramData%\ClaudeDesktopZhCn`，由计划任务检查。两处目录都只允许系统或管理员修改。
+- 检测到 Claude 刚更新或文件仍在变化时会等待下一次检查，避免与官方更新器并发写入。macOS 在版本稳定后会受控退出并恢复原先正在运行的 Claude；Windows 会等 Claude/Cowork 关闭后再修复，避免中断会话。
+- 新版只要基础 i18n 布局仍可语义识别，就会合并当前版本的 `en-US.json`：已有中文继续使用中文，新增加的 key 自动回退英文，不会因旧语言包缺 key 而显示空白。
+- 完整模式的 `app.asar` 增强锚点若不兼容，两端都会先回滚本次修改，再自动重试完全不改 `app.asar` 的基础模式；macOS 的真实官方应用在临时副本验证成功前不会被替换。
+- 同一 build 自动修复失败后会退避，不会每几分钟反复中断 Claude。此时请下载本项目新版再安装；新版安装会同步更新受保护的自动修复 payload。
+
+macOS 可先做只读兼容诊断：
+
+```bash
+/usr/bin/python3 scripts/patch_claude_zh_cn.py --doctor --json
+```
+
+诊断会输出 Claude 精确版本、动态发现的 i18n/JS 路径、语言白名单候选和完整模式的主进程 bundle，不修改应用。
 
 ## 文件说明
 
@@ -74,6 +93,8 @@ CC Switch skills 同步会扫描 `~/.cc-switch/skills` 下包含 `SKILL.md` 的�
 - `install-windows.bat`：Windows 安装 / 恢复菜单入口。
 - `scripts/install_windows.ps1`：Windows 汉化安装和卸载脚本。
 - `scripts/patch_claude_zh_cn.py`：真正执行补丁的 Python 脚本。
+- `scripts/macos_auto_repair.py`：macOS 更新检测与安全退避控制器。
+- `tests/test_patcher.py`：不依赖本机 Claude 安装的多版本布局、备份和原子提交回归测试。
 - `resources/manifest.json` / `manifest-zh-TW.json` / `manifest-zh-HK.json`：语言包信息。
 - `resources/frontend-zh-CN.json` / `frontend-zh-TW.json` / `frontend-zh-HK.json`：Claude 前端界面中文翻译。
 - `resources/frontend-hardcoded-zh-CN.json` / `frontend-hardcoded-zh-TW.json` / `frontend-hardcoded-zh-HK.json`：未走 i18n key 的前端硬编码文本映射，也用于在线账号页面的 DOM 翻译表。
@@ -86,46 +107,49 @@ CC Switch skills 同步会扫描 `~/.cc-switch/skills` 下包含 `SKILL.md` 的�
 
 - 安装时备份当前 `/Applications/Claude.app` 到同目录，名字类似：
   `Claude.backup-before-zh-CN-20260424-120000.app`
-- 安装前会先尝试恢复已有旧备份，清理上一轮汉化；没有旧备份时跳过并继续安装。
-- 恢复 / 卸载时选择同目录下最早的 `Claude.backup-before-zh-CN-*.app` 恢复为 `/Applications/Claude.app`，并删除其他备份。
+- 安装前只恢复 marker 中记录的当前 Claude build 和原始 `app.asar` 指纹所对应的备份；当前是官方更新后的未标记新版时绝不恢复旧版。
+- 恢复 / 卸载同样要求备份指纹匹配；匹配不到时保留当前应用并拒绝不安全恢复。
 - 复制 Claude.app 到临时目录并打补丁。
 - 给前端语言白名单加入当前选择的中文变体。
 - 两种安装模式都会汉化前端 bundle 中未走 i18n key 的硬编码文本，并修正中文语言显示名称。
 - 完整补丁模式会修改 `Contents/Resources/app.asar`：注入在线账号页面 DOM 翻译和语言锁定、汉化主进程菜单及模型选择器，并用等长替换关闭第三方网关模型名校验。
-- 跳过结构性 `app.asar` 的模式不会执行上述结构性注入和模型校验绕过，但仍会对少量主进程菜单文本做保持字节长度的替换。
+- 基础兼容模式不会执行上述结构性注入、菜单替换或模型校验绕过，`app.asar` 与 Electron 完整性信息保持逐字节不变。
 - 合并当前 Claude 版本的 `en-US.json` 和随包中文翻译：
   当前版本已有中文翻译的 key 会变中文，新版本新增但本包没有的 key 会保留英文，避免应用缺字段。
 - 写入 `~/Library/Application Support/Claude/config.json`，设置 `"locale"` 为所选语言代码（`zh-CN`、`zh-TW` 或 `zh-HK`）。完整补丁模式还会在在线页面加载时同步并锁定前端语言状态。
 - 对修改后的 Claude.app 及其内部 app/framework/原生二进制做一致的本机 ad-hoc 重签名，并清除 `com.apple.quarantine` 隔离属性。
 - 重新启动 Claude。
+- 把本次补丁器、语言资源和选择复制到 root 所有的受保护目录，并加载定时检查服务；更新后的 app 稳定落盘后会自动在临时副本重新汉化。
 - 可选菜单项 `4` 用 `y/n` 控制 Claude Desktop 自动更新：`y` 禁止自动更新，`n` 允许自动更新。若当前存在有效的 Claude-3p `configLibrary`，脚本会写入当前 applied 配置；否则写入 Claude Desktop enterprise policy。
 - 可选菜单项 `5` 用 `y/n` 控制 CC Switch skills 同步：`y` 会把 `~/.cc-switch/skills` 中缺失的 skill 软链接到 Claude Desktop 的本地 skills 目录，并更新对应 `manifest.json`；`n` 只删除之前同步产生的 CC Switch 软链接和对应 manifest 记录。该操作不需要管理员权限，不会覆盖同名 skill。
 
 ## Windows 脚本会做什么
 
 - 查找 Windows 版 Claude Desktop 安装目录。
-- 安装前会先尝试从 `resources\.zh-cn-backups` 恢复旧备份，清理上一轮汉化；没有旧备份时跳过并继续安装。
+- 安装前仅在当前版本带有效补丁 marker 时从 `resources\.zh-cn-backups` 恢复；marker 缺失表示官方新版或干净安装，不会跨版本回灌旧备份。
 - 修改前只备份实际会改动的文件到 Claude 安装目录下的 `resources\.zh-cn-backups`；模式 1 不修改 `app.asar` 或 `Claude.exe`，模式 2 会备份并修改它们。
-- 复制本仓库现有中文资源，不使用其他语言包项目里的 JSON：
-  - `resources/frontend-zh-CN.json` / `frontend-zh-TW.json` / `frontend-zh-HK.json` -> `ion-dist\i18n\` 对应语言代码 `.json`
+- 将本仓库中文翻译与当前 Claude 版本英文资源按 key 合并，不使用其他语言包项目里的 JSON：
+  - `resources/frontend-zh-CN.json` / `frontend-zh-TW.json` / `frontend-zh-HK.json` -> 动态发现的主前端 `i18n` / `locales` 目录中对应语言代码 `.json`
   - `resources/desktop-zh-CN.json` / `desktop-zh-TW.json` / `desktop-zh-HK.json` -> `resources\` 对应语言代码 `.json`
-  - `resources/statsig-zh-CN.json` / `statsig-zh-TW.json` / `statsig-zh-HK.json` -> `ion-dist\i18n\statsig\` 对应语言代码 `.json`
+  - `resources/statsig-zh-CN.json` / `statsig-zh-TW.json` / `statsig-zh-HK.json` -> 上述动态目录的 `statsig\` 子目录
 - 给前端语言白名单加入当前选择的中文变体。
 - 汉化前端 bundle 中未走 i18n JSON 的硬编码界面文本，例如侧边栏入口、配置页标签和模型选择项。
 - 模式 2 会在在线账号登录 / 聊天页面注入显示层 DOM 翻译，覆盖聊天、项目、Artifacts 等远程页面；模式 1 会跳过此项，因为它需要修改 `app.asar`。
 - Windows 的模式 2 会直接改写当前 Claude 的 `app.asar` 并同步改写 `Claude.exe` 内嵌完整性哈希，导致 Authenticode 签名 `HashMismatch`；Cowork VM 服务可能拒绝客户端并报 `RPC pipe closed`。如果需要 Cowork 沙箱/截图工作区，请使用模式 1，并通过网关或 CC Switch 模型别名映射解决第三方模型名校验。
+- 如果模式 2 在新版 Claude 上没有通过结构或完整性验证，安装事务会恢复本次改动并自动改用模式 1；两种模式都失败时才记录该 build 的失败状态并停止重复尝试。
 - 写入 Windows 用户配置，将语言设置为所选语言代码（`zh-CN`、`zh-TW` 或 `zh-HK`）。
 - 可选菜单项 `4` 用 `y/n` 控制 Claude Desktop 自动更新：`y` 禁止自动更新，`n` 允许自动更新。若当前存在有效的 Claude-3p `configLibrary`，脚本会写入当前 applied 配置；否则写入 `HKCU\SOFTWARE\Policies\Claude` policy。
 - 可选菜单项 `5` 用 `y/n` 控制 CC Switch skills 同步：`y` 会把 `%USERPROFILE%\.cc-switch\skills` 中缺失的 skill 以软链接加入 Claude Desktop 的本地 skills 目录，并把 `SKILL.md` frontmatter 里的 `name` 和 `description` 写入对应 `manifest.json`；`n` 只删除之前同步产生、且指向 CC Switch skills 目录内的软链接和对应 manifest 记录。脚本会从当前用户的 AppData 动态扫描 Claude-3p skills plugin，不写死 session UUID，不覆盖同名 skill，也不删除 CC Switch 源目录。
 - 重启 Claude Desktop。
+- 把维护脚本和语言资源复制到 ACL 受保护的 `%ProgramData%\ClaudeDesktopZhCn` 并注册计划任务；新版本目录稳定且 Claude 未运行时自动重新应用。
 
 ## 卸载 / 恢复
 
-执行对应平台的安装入口并选择 `3`。macOS 会恢复 `/Applications` 下最早的 `Claude.backup-before-zh-CN-*.app` 并删除其他补丁备份；Windows 会恢复备份文件、删除三种中文资源并把用户语言设置恢复为 `en-US`。
+执行对应平台的安装入口并选择 `3`。macOS 只恢复与当前 marker 精确匹配的原版备份；Windows 只恢复当前版本的 marker 备份。两端都会先停用并删除自动修复服务，随后把用户语言设置恢复为 `en-US`，不会出现“刚卸载又被后台补回”的情况。
 
 ## 注意事项
 
-- Claude Desktop 更新可能覆盖补丁。建议先恢复补丁，再更新 Claude Desktop，最后使用本项目最新版本重新安装。
+- Claude Desktop 更新会覆盖应用内部资源，但自动修复服务会在更新完成后重新应用汉化。若新版基础结构不兼容，服务会保留官方英文应用并停止高频重试；此时更新本项目后重新安装即可。
 - macOS 两种安装模式都会对修改后的应用做本机 ad-hoc 重签名；Windows 模式 2 会破坏 `Claude.exe` 的 Authenticode 签名。签名相关功能是否可用，应以当前 Claude Desktop 版本的实际验证结果为准。
 - 在线账号页面由 `claude.ai` 动态更新，DOM 汉化依赖英文原文匹配；上游文案变化后可能出现少量漏翻，需要更新本项目词表。
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ CC Switch skills 同步会扫描 `~/.cc-switch/skills` 下包含 `SKILL.md` 的�
 ## 更新后自动恢复与新版兼容
 
 - 自动修复只运行本次安装时复制的脚本和语言资源，不会以 root/SYSTEM 身份从网络下载或执行新代码。
-- macOS payload 位于 `/Library/Application Support/ClaudeDesktopZhCN`，由 LaunchDaemon 每 5 分钟检查一次；Windows payload 位于 `%ProgramData%\ClaudeDesktopZhCn`，由计划任务检查。两处目录都只允许系统或管理员修改。
+- macOS payload 位于 `/Library/Application Support/ClaudeDesktopZhCN`，由 LaunchDaemon 在检测到官方更新时立即检查（监听 `Claude.app/Contents/Info.plist` 变化），并以每 5 分钟轮询作为兜底；Windows payload 位于 `%ProgramData%\ClaudeDesktopZhCn`，由计划任务检查。两处目录都只允许系统或管理员修改。
 - 检测到 Claude 刚更新或文件仍在变化时会等待下一次检查，避免与官方更新器并发写入。macOS 在版本稳定后会受控退出并恢复原先正在运行的 Claude；Windows 会等 Claude/Cowork 关闭后再修复，避免中断会话。
 - 新版只要基础 i18n 布局仍可语义识别，就会合并当前版本的 `en-US.json`：已有中文继续使用中文，新增加的 key 自动回退英文，不会因旧语言包缺 key 而显示空白。
 - 完整模式的 `app.asar` 增强锚点若不兼容，两端都会先回滚本次修改，再自动重试完全不改 `app.asar` 的基础模式；macOS 的真实官方应用在临时副本验证成功前不会被替换。

--- a/docs/agent/AGENT_HANDOFF.md
+++ b/docs/agent/AGENT_HANDOFF.md
@@ -5,19 +5,30 @@
 - 分支：main（主分支）
 
 ## 项目结构
-- `scripts/patch_claude_zh_cn.py` — 主补丁脚本（macOS + Windows）
+- `scripts/patch_claude_zh_cn.py` — macOS 补丁、诊断和安全提交脚本
+- `scripts/macos_auto_repair.py` — macOS LaunchDaemon 更新检测与自动修复控制器
+- `scripts/install_windows.ps1` — Windows 补丁、卸载和计划任务维护脚本
 - `resources/` — 中文翻译资源文件（zh-CN、zh-TW、zh-HK）
 - `install-mac.command` — macOS 安装入口
 - `install-windows.bat` — Windows 安装入口
+- `tests/test_patcher.py` — 不依赖 Claude 安装的跨版本兼容与回滚测试
 - `docs/` — GitHub Pages 文档网站
 - `.github/workflows/` — CI/CD 工作流
 
 ## 常用命令
 - macOS 安装：`sudo python3 scripts/patch_claude_zh_cn.py --app /Applications/Claude.app`
+- macOS 只读诊断：`python3 scripts/patch_claude_zh_cn.py --doctor --json`
 - Windows 安装：右键 `install-windows.bat` 以管理员身份运行
 - 卸载/恢复：运行安装脚本，选择恢复选项
+- 回归测试：`python3 -m unittest discover -s tests -v`
+- Python 语法：`python3 -m py_compile scripts/patch_claude_zh_cn.py scripts/macos_auto_repair.py`
+- macOS 入口语法：`bash -n install-mac.command`
 
 ## 注意事项
-- 补丁会修改 Claude Desktop 的本地资源文件
+- 补丁会修改 Claude Desktop 的本地资源文件，并安装系统级自动修复服务
 - 安装前请完全退出 Claude Desktop
-- 更新 Claude 后可能需要重新运行补丁
+- 不得恢复没有有效 marker 或与当前 build/源指纹不匹配的旧备份，以免把官方新版降级
+- 前端资源必须按语义和递归布局发现，不能重新写死 `assets/v1`、固定 hash 文件名或完整语言数组
+- 新版英文资源与项目中文词表按 key 合并；未翻译的新 key 保留英文
+- 完整模式不兼容时先回滚并退到基础模式；基础模式不得读写 `app.asar` 或可执行文件完整性信息
+- macOS 自动修复 payload 位于 `/Library/Application Support/ClaudeDesktopZhCN`；Windows 位于 `%ProgramData%\ClaudeDesktopZhCn`。两者都禁止从网络下载并以 root/SYSTEM 执行代码

--- a/docs/agent/QUICKSTART.md
+++ b/docs/agent/QUICKSTART.md
@@ -1,5 +1,7 @@
 # Quickstart
 
-1. Read AGENT_HANDOFF.md
-2. Run onboarding checks
-3. Verify tests and smoke
+1. Read `AGENT_HANDOFF.md` and `README.md`.
+2. Run `python3 -m py_compile scripts/patch_claude_zh_cn.py scripts/macos_auto_repair.py`.
+3. Run `python3 -m unittest discover -s tests -v` and `bash -n install-mac.command`.
+4. For Windows changes, require the PowerShell 5.1 parser and dynamic-layout fixture jobs in `.github/workflows/test.yml` to pass.
+5. Never restore a backup without a current, identity-matching patch marker.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Claude Desktop 中文补丁 — 一键汉化 · 双平台 · 可恢复</title>
-  <meta name="description" content="免费开源的 Claude Desktop 中文汉化补丁：macOS 与 Windows 一键安装，支持简体、繁体（中国台湾）、繁体（中国香港），安装前自动备份、随时可恢复，官方更新后持续跟进。">
+  <meta name="description" content="免费开源的 Claude Desktop 中文汉化补丁：macOS 与 Windows 一键安装，支持三种中文，版本指纹备份可恢复，Claude 更新后自动补回汉化。">
   <meta property="og:title" content="Claude Desktop 中文补丁">
-  <meta property="og:description" content="一键把 Claude Desktop 翻成中文。双平台、三种中文变体、自动备份可恢复、持续维护。">
+  <meta property="og:description" content="一键把 Claude Desktop 翻成中文。双平台、三种中文变体、更新后自动恢复、版本安全可回滚。">
   <style>
     :root {
       color-scheme: light;
@@ -569,7 +569,7 @@
           <span class="stamp-word">翻成中文。</span>
         </h1>
         <p class="hero-lead" data-reveal style="--delay:140ms">
-          免费、开源、持续维护的 <span class="term">Claude Desktop</span> 汉化补丁。<b>一条脚本装上，界面即刻变中文</b> —— macOS 与 Windows 双平台，简体、繁体（中国台湾）、繁体（中国香港）任你选。官方更新后同步跟进，遇到漏翻随时反馈、随时修。
+          免费、开源、持续维护的 <span class="term">Claude Desktop</span> 汉化补丁。<b>一条脚本装上，界面即刻变中文</b> —— macOS 与 Windows 双平台，简体、繁体（中国台湾）、繁体（中国香港）任你选。官方更新覆盖资源后，受保护的后台服务会自动补回汉化。
         </p>
         <div class="hero-cta" data-reveal style="--delay:210ms">
           <a class="btn btn-primary" href="https://github.com/javaht/claude-desktop-zh-cn/releases/latest">立即下载补丁 <span class="arrow">→</span></a>
@@ -579,7 +579,7 @@
           <div><dt>双平台</dt><dd>macOS + Windows</dd></div>
           <div><dt>三种中文</dt><dd>简体 · 繁·中国台湾 · 繁·中国香港</dd></div>
           <div><dt>安全可逆</dt><dd>自动备份 · 一键恢复</dd></div>
-          <div><dt>持续维护</dt><dd>跟随官方更新</dd></div>
+          <div><dt>更新不掉</dt><dd>检测新版 · 自动补回</dd></div>
         </dl>
       </div>
 
@@ -634,7 +634,7 @@
         <article class="feature">
           <span class="fno">03</span>
           <h3>安全备份 · 一键恢复</h3>
-          <p>安装前自动备份原始 Claude，随时可从备份恢复或彻底卸载，装坏也退得回去。</p>
+          <p>备份记录 Claude build 与原始文件指纹，只恢复精确匹配版本；新版绝不会被旧备份降级，提交失败自动回滚。</p>
         </article>
         <article class="feature">
           <span class="fno">04</span>
@@ -656,6 +656,7 @@
       <div class="more-strip" data-reveal style="--delay:80ms">
         <span>登录后的 claude.ai 在线页面也汉化</span>
         <span>菜单内一键开关自动更新</span>
+        <span>官方更新后自动恢复汉化</span>
         <span>macOS 原生菜单同步汉化</span>
         <span>安装写入失败自动容错</span>
       </div>
@@ -705,9 +706,9 @@
             <li>退出 Claude Desktop。</li>
             <li>双击 <code>install-mac.command</code>，选择「安装中文补丁」。</li>
             <li>选语言（<b>1</b> 简体 / <b>2</b> 繁体·中国台湾 / <b>3</b> 繁体·中国香港），按提示输入 Mac 登录密码。</li>
-            <li>Claude 自动重启即生效；若没切换，到左下角账号菜单 <span class="term">Language</span> 里手动选。</li>
+            <li>Claude 自动重启即生效，并启用受保护的更新修复服务；若没切换，到 <span class="term">Language</span> 里手动选。</li>
           </ol>
-          <p class="os-note"><b>想更稳？</b> 菜单里还有「安全模式」，跳过 <span class="term">app.asar</span> 结构性补丁，只做等长菜单汉化，兼容性更高。</p>
+          <p class="os-note"><b>想更稳？</b> 菜单里的「基础兼容模式」完全不读写 <span class="term">app.asar</span>；完整模式遇到新版增强锚点不兼容时也会自动回退。</p>
         </article>
 
         <article class="os-card" data-reveal style="--delay:80ms">
@@ -719,15 +720,15 @@
             <li>退出 Claude Desktop。</li>
             <li>右键 <code>install-windows.bat</code>，选择以管理员身份运行。</li>
             <li>先选安装模式，再选语言（简体 / 繁·中国台湾 / 繁·中国香港）。</li>
-            <li>脚本自动备份资源、写入中文并重启 Claude。</li>
+            <li>脚本自动备份资源、写入中文、重启 Claude，并注册受保护的自动修复任务。</li>
           </ol>
-          <p class="os-note"><b>三种模式：</b> ① Cowork 兼容（跳过 <span class="term">app.asar</span>）② 官方账号登录 ③ 第三方 API 实验。需要 Cowork 沙箱 / 截图工作区请选 ①。</p>
+          <p class="os-note"><b>两种模式：</b> ① Cowork 兼容（跳过 <span class="term">app.asar</span>）② 官方账号在线汉化。② 未通过新版结构验证时会先完整回滚，再自动退到 ①；需要 Cowork 沙箱 / 截图工作区请直接选 ①。</p>
         </article>
       </div>
 
       <div class="safety-bar" data-reveal>
         <span class="ic" aria-hidden="true">↺</span>
-        <span>所有改动只动本机 Claude 的本地资源，<b>安装前自动备份</b>。要恢复？再跑一次脚本，选「恢复 / 卸载」即可。</span>
+        <span>所有改动只动本机资源，<b>安装前按版本指纹备份</b>。卸载会先移除后台修复任务，再恢复精确匹配的原版，不会刚卸载又被补回。</span>
       </div>
     </section>
 
@@ -776,7 +777,7 @@
 
     <footer>
       <p class="foot-disc">
-        <b>免责声明：</b>本项目为非官方中文补丁，与 Anthropic 无关，仅修改本机 Claude Desktop 的本地资源文件。Claude Desktop 更新后资源结构可能变化，若补丁失效，请先更新本项目或重新运行安装脚本。开源社区维护。
+        <b>免责声明：</b>本项目为非官方中文补丁，与 Anthropic 无关，仅修改本机 Claude Desktop 的本地资源文件。若新版结构无法通过兼容验证，自动修复会保留官方应用并退避；请更新本项目后重新安装。开源社区维护。
       </p>
       <nav class="foot-links" aria-label="页脚链接">
         <a href="https://github.com/javaht/claude-desktop-zh-cn">GitHub</a><span class="dot">/</span>

--- a/install-mac.command
+++ b/install-mac.command
@@ -54,6 +54,7 @@ check_release_update
 
 echo "Claude Desktop 中文补丁"
 echo "目录: $DIR"
+echo "安装成功后会启用受保护的自动修复服务；Claude 更新后会自动补回汉化。"
 echo
 
 ACTION="${CLAUDE_ACTION:-}"
@@ -61,7 +62,7 @@ SKIP_ASAR_PATCH="${CLAUDE_SKIP_ASAR_PATCH:-0}"
 if [ -z "$ACTION" ]; then
   echo "请选择操作："
   echo "  [1] 安装中文补丁(官方订阅与第三方api均可使用：Cowork 沙箱/工作区不可用看群公告)"
-  echo "  [2] 安装中文补丁(第三方api可用：第三方模型需借助ccswitch映射(Cowork 沙箱/工作区不可用看群公告))"
+  echo "  [2] 基础兼容模式（完全不修改 app.asar；新版增强补丁不兼容时也会自动回退到此模式）"
   echo "  [3] 恢复原样 / 卸载补丁"
   echo "  [4] 自动更新设置（y=禁止自动更新，n=允许自动更新）"
   echo "  [5] 同步CC Switch skills （y=同步，n=删除之前的同步）"
@@ -140,7 +141,7 @@ esac
 if [ "$ACTION" = "install" ]; then
   echo "选择的语言: $LANG_CODE"
   if [ -n "$SKIP_ASAR_ARG" ]; then
-    echo "安全模式: 跳过结构性 app.asar 补丁，仅应用等长菜单汉化补丁"
+    echo "基础模式: 完全不读写 app.asar 或二进制完整性信息"
   fi
   echo
 fi

--- a/install-mac.command
+++ b/install-mac.command
@@ -26,15 +26,34 @@ try:
         metadata = json.load(f)
     repo = metadata["repo"]
     current = str(metadata["release"])
-    req = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}/releases/latest",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "claude-desktop-zh-cn-update-check",
-        },
-    )
-    with urllib.request.urlopen(req, timeout=3) as response:
-        latest = str(json.load(response)["tag_name"])
+
+    def fetch_json(url, headers):
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=3) as response:
+            return json.load(response)
+
+    latest = None
+    try:
+        latest = str(
+            fetch_json(
+                f"https://api.github.com/repos/{repo}/releases/latest",
+                {
+                    "Accept": "application/vnd.github+json",
+                    "User-Agent": "claude-desktop-zh-cn-update-check",
+                },
+            )["tag_name"]
+        )
+    except Exception:
+        # api.github.com is often unreachable from mainland China; fall back to
+        # the jsDelivr package API, which mirrors GitHub tags and stays reachable.
+        versions = fetch_json(
+            f"https://data.jsdelivr.com/v1/package/gh/{repo}",
+            {"User-Agent": "claude-desktop-zh-cn-update-check"},
+        ).get("versions") or []
+        if versions:
+            latest = str(versions[0])
+    if not latest:
+        raise RuntimeError("no release info")
 
     def version_key(value):
         parts = [int(part) for part in re.findall(r"\d+", value)]
@@ -42,9 +61,10 @@ try:
 
     if version_key(latest) > version_key(current):
         print(
-            f"检测到 GitHub Releases 已发布新版 {latest}，当前脚本包为 {current}。"
+            f"检测到项目已发布新版 {latest}，当前脚本包为 {current}。"
             "建议及时更新。本次操作会继续执行。"
         )
+        print("国内网络下载较慢时，可参考 README 的「国内用户下载」章节。")
 except Exception:
     pass
 PY

--- a/resources/manifest-zh-HK.json
+++ b/resources/manifest-zh-HK.json
@@ -2,11 +2,11 @@
   "language": "zh-HK",
   "label": "繁體中文（中國香港）",
   "source_app": "Claude Desktop",
-  "frontend_strings": 12329,
-  "desktop_shell_strings": 355,
+  "frontend_strings": 16136,
+  "desktop_shell_strings": 357,
   "notes": [
     "frontend-zh-HK.json is merged by key with the target machine's en-US.json",
     "new unknown keys fall back to English",
-    "run install.command again after Claude Desktop updates"
+    "the protected auto-repair service reapplies the patch after Claude Desktop updates"
   ]
 }

--- a/resources/manifest-zh-TW.json
+++ b/resources/manifest-zh-TW.json
@@ -2,11 +2,11 @@
   "language": "zh-TW",
   "label": "繁體中文（中國台灣）",
   "source_app": "Claude Desktop",
-  "frontend_strings": 12329,
-  "desktop_shell_strings": 355,
+  "frontend_strings": 16136,
+  "desktop_shell_strings": 357,
   "notes": [
     "frontend-zh-TW.json is merged by key with the target machine's en-US.json",
     "new unknown keys fall back to English",
-    "run install.command again after Claude Desktop updates"
+    "the protected auto-repair service reapplies the patch after Claude Desktop updates"
   ]
 }

--- a/resources/manifest.json
+++ b/resources/manifest.json
@@ -2,11 +2,11 @@
   "language": "zh-CN",
   "label": "简体中文",
   "source_app": "Claude Desktop",
-  "frontend_strings": 12325,
-  "desktop_shell_strings": 355,
+  "frontend_strings": 16173,
+  "desktop_shell_strings": 357,
   "notes": [
     "frontend-zh-CN.json is merged by key with the target machine's en-US.json",
     "new unknown keys fall back to English",
-    "run install.command again after Claude Desktop updates"
+    "the protected auto-repair service reapplies the patch after Claude Desktop updates"
   ]
 }

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,11 +1,12 @@
 ﻿param(
     [switch]$Interactive,
+    [switch]$LibraryMode,
     [switch]$SkipAsarPatch,
     [ValidateSet("safe", "official")]
     [string]$PatchMode = "safe",
 
     [Parameter(Position = 0)]
-    [ValidateSet("install", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills")]
+    [ValidateSet("install", "maintain", "uninstall", "disable-updates", "enable-updates", "sync-skills", "unsync-skills")]
     [string]$Action = "install",
 
     [Parameter(Position = 1)]
@@ -21,14 +22,20 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
 $Utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-$BaseLanguageList = '["en-US","de-DE","fr-FR","ko-KR","ja-JP","es-419","es-ES","it-IT","hi-IN","pt-BR","id-ID"'
-$LanguageListPattern = [System.Text.RegularExpressions.Regex]::Escape($BaseLanguageList) + '(?:(?:,"zh-CN")|(?:,"zh-TW")|(?:,"zh-HK"))*\]'
 $AsarPatchTargetFallback = ".vite/build/index.js"
 $AsarIntegrityBlockSize = 4 * 1024 * 1024
 $OnlineLocaleMainMarker = "__claudeZhOnlineLocaleMain"
 $MenuRuntimeMarker = "__claudeZhMenuRuntimePatch"
 $OnlineTranslationMaxSourceLength = 1000
+$WindowsMaintenanceSettleSeconds = 90
+$WindowsMaintenanceFailureRetrySeconds = 6 * 60 * 60
 $script:CurrentBackupSetPath = $null
+$script:InstallTransactionActive = $false
+$script:InstallTransactionResourcesPath = $null
+$script:InstallTransactionCreatedFiles = [System.Collections.Generic.List[string]]::new()
+$script:LastInstallRollbackSucceeded = $true
+$script:IsMaintenanceRun = $false
+$script:RemoveMaintenancePayloadAfterLog = $false
 $script:DetectedUnpackagedClaudePaths = @()
 $script:DetectedMultipleClaudeInstalls = $false
 $script:InstallLogPath = $null
@@ -90,6 +97,9 @@ function Test-SkipReleaseUpdateCheck {
 }
 
 function Test-GitHubReleaseUpdate {
+    if ($LibraryMode -or $Action -eq "maintain") {
+        return
+    }
     if (Test-SkipReleaseUpdateCheck) {
         return
     }
@@ -169,8 +179,6 @@ function Read-InteractiveSelection {
         }
     }
 
-    Write-Host ""
-    Invoke-PreInstallCleanup
     Write-Host ""
     Write-Host "请选择要安装的语言："
     Write-Host "[1] 简体中文"
@@ -255,18 +263,18 @@ function Test-UnpackagedClaudeAppDirectory {
 }
 
 function Get-UnpackagedClaudePaths {
-    $localAppData = [Environment]::GetFolderPath('LocalApplicationData')
-    if (-not $localAppData) {
-        return @()
+    $directories = @()
+    foreach ($localAppData in @(Get-OriginalLocalAppDataRoots)) {
+        $unpackagedBase = Join-Path $localAppData "AnthropicClaude"
+        if (-not (Test-Path -LiteralPath $unpackagedBase -PathType Container)) {
+            continue
+        }
+        $directories += Get-ChildItem -LiteralPath $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
+            Where-Object { Test-UnpackagedClaudeAppDirectory $_ }
     }
 
-    $unpackagedBase = Join-Path $localAppData "AnthropicClaude"
-    if (-not (Test-Path $unpackagedBase)) {
-        return @()
-    }
-
-    return @(Get-ChildItem $unpackagedBase -Directory -Filter "app-*" -ErrorAction SilentlyContinue |
-        Where-Object { Test-UnpackagedClaudeAppDirectory $_ } |
+    return @($directories |
+        Sort-Object FullName -Unique |
         Sort-Object `
             @{ Expression = { Get-UnpackagedClaudeVersion $_ }; Descending = $true },
             @{ Expression = { $_.LastWriteTime }; Descending = $true } |
@@ -287,8 +295,183 @@ function Write-AsarCoworkSignatureWarning {
     Write-Host ""
 }
 
+function Get-OriginalLocalAppDataRoots {
+    $roots = @()
+    $hasOriginalContext = $false
+    if ($env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA) {
+        $roots += $env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA
+        $hasOriginalContext = $true
+    }
+    if ($env:CLAUDE_ZH_ORIGINAL_USER_PROFILE) {
+        $roots += Join-Path $env:CLAUDE_ZH_ORIGINAL_USER_PROFILE "AppData\Local"
+        $hasOriginalContext = $true
+    }
+    if (-not $hasOriginalContext) {
+        if ($env:LOCALAPPDATA) {
+            $roots += $env:LOCALAPPDATA
+        }
+        $systemValue = [Environment]::GetFolderPath('LocalApplicationData')
+        if ($systemValue) {
+            $roots += $systemValue
+        }
+    }
+    return @($roots | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -Unique)
+}
+
+function Get-OriginalAppDataRoots {
+    $roots = @()
+    $hasOriginalContext = $false
+    if ($env:CLAUDE_ZH_ORIGINAL_APPDATA) {
+        $roots += $env:CLAUDE_ZH_ORIGINAL_APPDATA
+        $hasOriginalContext = $true
+    }
+    if ($env:CLAUDE_ZH_ORIGINAL_USER_PROFILE) {
+        $roots += Join-Path $env:CLAUDE_ZH_ORIGINAL_USER_PROFILE "AppData\Roaming"
+        $hasOriginalContext = $true
+    }
+    if (-not $hasOriginalContext) {
+        if ($env:APPDATA) {
+            $roots += $env:APPDATA
+        }
+        $systemValue = [Environment]::GetFolderPath('ApplicationData')
+        if ($systemValue) {
+            $roots += $systemValue
+        }
+    }
+    return @($roots | Where-Object { $_ -and (Test-Path -LiteralPath $_) } | Select-Object -Unique)
+}
+
+function Get-FrontendJavaScriptFiles {
+    param([string]$ResourcesPath)
+
+    $assetsRoot = Join-Path $ResourcesPath "ion-dist\assets"
+    if (-not (Test-Path -LiteralPath $assetsRoot -PathType Container)) {
+        throw "未找到前端 assets 目录: $assetsRoot"
+    }
+
+    $files = @(Get-ChildItem -LiteralPath $assetsRoot -Recurse -File -Filter "*.js" -ErrorAction SilentlyContinue |
+        Sort-Object FullName)
+    if ($files.Count -eq 0) {
+        throw "未找到前端 JS bundle: $assetsRoot"
+    }
+    return $files
+}
+
+function Get-FrontendI18nDirectory {
+    param([string]$ResourcesPath)
+
+    $preferred = Join-Path $ResourcesPath "ion-dist\i18n"
+    if (Test-Path -LiteralPath (Join-Path $preferred "en-US.json") -PathType Leaf) {
+        return $preferred
+    }
+
+    $ionDist = Join-Path $ResourcesPath "ion-dist"
+    if (-not (Test-Path -LiteralPath $ionDist -PathType Container)) {
+        throw "未找到前端 ion-dist 目录: $ionDist"
+    }
+    $candidates = @()
+    foreach ($englishFile in @(Get-ChildItem -LiteralPath $ionDist -Recurse -File -Filter "en-US.json" -ErrorAction SilentlyContinue)) {
+        $lowerPath = $englishFile.FullName.ToLowerInvariant()
+        if ($lowerPath.Contains("\statsig\") -or $lowerPath.Contains("\node_modules\")) {
+            continue
+        }
+        $score = [int64]$englishFile.Length
+        if ($englishFile.Directory.Name -in @("i18n", "locales")) {
+            $score += 1000000000
+        }
+        $candidates += [pscustomobject]@{ Score = $score; Path = $englishFile.Directory.FullName }
+    }
+    $selected = $candidates |
+        Sort-Object -Property `
+            @{ Expression = { $_.Score }; Descending = $true },
+            @{ Expression = { $_.Path }; Descending = $false } |
+        Select-Object -First 1
+    if (-not $selected) {
+        throw "无法动态定位前端 en-US.json；Claude 资源布局可能已变化。"
+    }
+    return [string]$selected.Path
+}
+
+function Update-LanguageArraysInText {
+    param(
+        [string]$Text,
+        [string]$Lang
+    )
+
+    # Match arrays made only of locale-like string literals. Requiring en-US and
+    # several long-standing Claude locales avoids changing unrelated JS arrays,
+    # while preserving every locale and ordering shipped by upstream.
+    $arrayPattern = [System.Text.RegularExpressions.Regex]::new(
+        '\[(?<items>\s*["''][A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+["''](?:\s*,\s*["''][A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+["'']){3,}\s*)\]',
+        [System.Text.RegularExpressions.RegexOptions]::Singleline
+    )
+    $localePattern = [System.Text.RegularExpressions.Regex]::new('(?<quote>["''])(?<locale>[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+)\k<quote>')
+    $knownLocales = @("de-DE", "fr-FR", "ko-KR", "ja-JP", "es-ES", "it-IT", "pt-BR")
+    $candidateCount = 0
+    $alreadyCount = 0
+    $changedCount = 0
+    $replacements = [System.Collections.Generic.List[object]]::new()
+
+    foreach ($match in $arrayPattern.Matches($Text)) {
+        $localeMatches = @($localePattern.Matches($match.Groups["items"].Value))
+        $locales = @($localeMatches | ForEach-Object { $_.Groups["locale"].Value })
+        if ($locales -notcontains "en-US") {
+            continue
+        }
+        $knownCount = @($knownLocales | Where-Object { $locales -contains $_ }).Count
+        if ($knownCount -lt 3) {
+            continue
+        }
+
+        $candidateCount += 1
+        if ($locales -contains $Lang) {
+            $alreadyCount += 1
+            continue
+        }
+
+        $items = $match.Groups["items"].Value
+        $trailingWhitespace = [System.Text.RegularExpressions.Regex]::Match($items, '\s*$').Value
+        $core = $items.Substring(0, $items.Length - $trailingWhitespace.Length)
+        $quote = $localeMatches[0].Groups["quote"].Value
+        $separatorMatches = [System.Text.RegularExpressions.Regex]::Matches(
+            $items,
+            '(?<separator>\s*,\s*)["''][A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})+["'']'
+        )
+        $separator = if ($separatorMatches.Count -gt 0) {
+            $separatorMatches[$separatorMatches.Count - 1].Groups["separator"].Value
+        } else {
+            ","
+        }
+        $replacement = "[$core$separator$quote$Lang$quote$trailingWhitespace]"
+        $replacements.Add([pscustomobject]@{
+            Index = $match.Index
+            Length = $match.Length
+            Value = $replacement
+        })
+        $changedCount += 1
+    }
+
+    $updated = $Text
+    foreach ($replacement in @($replacements | Sort-Object Index -Descending)) {
+        $updated = $updated.Substring(0, $replacement.Index) +
+            $replacement.Value +
+            $updated.Substring($replacement.Index + $replacement.Length)
+    }
+
+    return @{
+        Text = $updated
+        CandidateCount = $candidateCount
+        AlreadyCount = $alreadyCount
+        ChangedCount = $changedCount
+    }
+}
+
 function Find-ClaudePath {
-    $packages = @(Get-AppxPackage -Name "Claude" -ErrorAction SilentlyContinue)
+    $packages = @()
+    if ($env:CLAUDE_ZH_ORIGINAL_USER_SID) {
+        $packages += @(Get-AppxPackage -User $env:CLAUDE_ZH_ORIGINAL_USER_SID -Name "Claude" -ErrorAction SilentlyContinue)
+    }
+    $packages += @(Get-AppxPackage -Name "Claude" -ErrorAction SilentlyContinue)
     foreach ($package in $packages) {
         if ($package.InstallLocation -and (Test-Path $package.InstallLocation)) {
             return $package.InstallLocation
@@ -380,17 +563,21 @@ function Get-ClaudeResourcesPath {
 }
 
 function Get-ClaudeConfigPaths {
-    if (-not $env:LOCALAPPDATA) {
-        return @()
-    }
-
     $configPaths = @()
-    if ($env:APPDATA) {
-        $configPaths += Join-Path $env:APPDATA "Claude\config.json"
-        $configPaths += Join-Path $env:APPDATA "Claude-3p\config.json"
+    foreach ($appData in @(Get-OriginalAppDataRoots)) {
+        $configPaths += Join-Path $appData "Claude\config.json"
+        $configPaths += Join-Path $appData "Claude-3p\config.json"
     }
 
     $packageNames = @()
+    if ($env:CLAUDE_ZH_ORIGINAL_USER_SID) {
+        $userPackages = @(Get-AppxPackage -User $env:CLAUDE_ZH_ORIGINAL_USER_SID -Name "Claude" -ErrorAction SilentlyContinue)
+        foreach ($package in $userPackages) {
+            if ($package.PackageFamilyName) {
+                $packageNames += $package.PackageFamilyName
+            }
+        }
+    }
     $packages = @(Get-AppxPackage -Name "Claude" -ErrorAction SilentlyContinue)
     foreach ($package in $packages) {
         if ($package.PackageFamilyName) {
@@ -398,19 +585,24 @@ function Get-ClaudeConfigPaths {
         }
     }
 
-    if ($packageNames.Count -eq 0) {
-        $packageRoot = Join-Path $env:LOCALAPPDATA "Packages"
+    foreach ($localAppData in @(Get-OriginalLocalAppDataRoots)) {
+        $packageRoot = Join-Path $localAppData "Packages"
         $packageDirs = @(Get-ChildItem (Join-Path $packageRoot "Claude_*") -Directory -ErrorAction SilentlyContinue |
             Sort-Object LastWriteTime -Descending)
         foreach ($packageDir in $packageDirs) {
-            $packageNames += $packageDir.Name
+            $configPaths += Join-Path $packageDir.FullName "LocalCache\Roaming\Claude\config.json"
+            $configPaths += Join-Path $packageDir.FullName "LocalCache\Roaming\Claude-3p\config.json"
         }
     }
 
-    foreach ($packageName in @($packageNames | Select-Object -Unique)) {
-        $packagePath = Join-Path (Join-Path $env:LOCALAPPDATA "Packages") $packageName
-        $configPaths += Join-Path $packagePath "LocalCache\Roaming\Claude\config.json"
-        $configPaths += Join-Path $packagePath "LocalCache\Roaming\Claude-3p\config.json"
+    foreach ($localAppData in @(Get-OriginalLocalAppDataRoots)) {
+        foreach ($packageName in @($packageNames | Select-Object -Unique)) {
+            $packagePath = Join-Path (Join-Path $localAppData "Packages") $packageName
+            if (Test-Path -LiteralPath $packagePath -PathType Container) {
+                $configPaths += Join-Path $packagePath "LocalCache\Roaming\Claude\config.json"
+                $configPaths += Join-Path $packagePath "LocalCache\Roaming\Claude-3p\config.json"
+            }
+        }
     }
 
     return @($configPaths | Select-Object -Unique)
@@ -458,6 +650,280 @@ function Get-ClaudeAppPathFromResources {
     return Split-Path -Parent $ResourcesPath
 }
 
+function Get-PatchMarkerPath {
+    param([string]$ResourcesPath)
+    return Join-Path $ResourcesPath ".claude-zh-cn.json"
+}
+
+function Get-WindowsPendingRestorePath {
+    param([string]$ResourcesPath)
+    return Join-Path $ResourcesPath ".claude-zh-cn.pending-restore.json"
+}
+
+function Get-PatchReleaseVersion {
+    try {
+        $scriptDir = if ($PSScriptRoot) { $PSScriptRoot } else { Split-Path -Parent $MyInvocation.MyCommand.Path }
+        $releasePath = Join-Path (Split-Path -Parent $scriptDir) "resources\release.json"
+        $release = Get-Content -LiteralPath $releasePath -Raw -Encoding UTF8 | ConvertFrom-Json
+        return [string]$release.release
+    }
+    catch {
+        return "unknown"
+    }
+}
+
+function Get-ClaudeAppIdentity {
+    param([hashtable]$Paths)
+
+    $appPath = [System.IO.Path]::GetFullPath([string]$Paths["App"]).TrimEnd('\', '/')
+    $exePath = Get-ClaudeExePath $appPath
+    $fileVersion = ""
+    $productVersion = ""
+    $exeLength = [int64]0
+    if ($exePath) {
+        try {
+            $exeItem = Get-Item -LiteralPath $exePath
+            $versionInfo = $exeItem.VersionInfo
+            $fileVersion = [string]$versionInfo.FileVersion
+            $productVersion = [string]$versionInfo.ProductVersion
+            $exeLength = [int64]$exeItem.Length
+        }
+        catch {
+        }
+    }
+    $asarLength = [int64]0
+    $asarPath = Join-Path ([string]$Paths["Resources"]) "app.asar"
+    if (Test-Path -LiteralPath $asarPath -PathType Leaf) {
+        $asarLength = [int64](Get-Item -LiteralPath $asarPath).Length
+    }
+    return [ordered]@{
+        installKind = [string]$Paths["InstallKind"]
+        appPath = $appPath
+        directoryName = Split-Path -Leaf $appPath
+        fileVersion = $fileVersion
+        productVersion = $productVersion
+        exeLength = $exeLength
+        asarLength = $asarLength
+    }
+}
+
+function Get-FileSha256HexFromPath {
+    param([string]$Path)
+
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    $sha = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $sha.ComputeHash($stream)
+        return ([System.BitConverter]::ToString($hash) -replace "-", "").ToLowerInvariant()
+    }
+    finally {
+        $sha.Dispose()
+        $stream.Dispose()
+    }
+}
+
+function Get-FilePrefixSha256Hex {
+    param(
+        [string]$Path,
+        [int]$MaximumBytes = 262144
+    )
+
+    $stream = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    try {
+        $count = [int][Math]::Min([int64]$MaximumBytes, $stream.Length)
+        $bytes = [byte[]]::new($count)
+        $offset = 0
+        while ($offset -lt $count) {
+            $read = $stream.Read($bytes, $offset, $count - $offset)
+            if ($read -le 0) {
+                break
+            }
+            $offset += $read
+        }
+        if ($offset -ne $count) {
+            throw "无法读取文件指纹: $Path"
+        }
+        $sha = [System.Security.Cryptography.SHA256]::Create()
+        try {
+            $hash = $sha.ComputeHash($bytes)
+            return ([System.BitConverter]::ToString($hash) -replace "-", "").ToLowerInvariant()
+        }
+        finally {
+            $sha.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Read-PatchMarker {
+    param([string]$ResourcesPath)
+
+    $path = Get-PatchMarkerPath $ResourcesPath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $null
+    }
+    try {
+        $marker = Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json
+        if (-not $marker -or -not $marker.appIdentity -or -not ([string]$marker.backupSet).Trim()) {
+            throw "marker 缺少 appIdentity 或 backupSet"
+        }
+        return $marker
+    }
+    catch {
+        Write-Host "  [警告] 汉化 marker 无效，不会恢复任何旧备份: $path" -ForegroundColor DarkYellow
+        return $null
+    }
+}
+
+function Test-PatchMarkerMatchesIdentity {
+    param(
+        [object]$Marker,
+        [hashtable]$Paths
+    )
+
+    if (-not $Marker -or -not $Marker.appIdentity) {
+        return $false
+    }
+    $current = Get-ClaudeAppIdentity $Paths
+    $recordedPath = [string]$Marker.appIdentity.appPath
+    if (-not $recordedPath -or -not $current.appPath.Equals($recordedPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    if ([string]$Marker.appIdentity.installKind -ne [string]$current.installKind) {
+        return $false
+    }
+    foreach ($propertyName in @("fileVersion", "productVersion", "exeLength", "asarLength")) {
+        $recorded = [string]$Marker.appIdentity.$propertyName
+        $actual = [string]$current.$propertyName
+        if ($recorded -and $actual -and $recorded -ne $actual) {
+            return $false
+        }
+    }
+    return $true
+}
+
+function Get-PatchedFrontendBundleRelativePaths {
+    param(
+        [string]$ResourcesPath,
+        [string]$Lang
+    )
+
+    $relativePaths = @()
+    foreach ($file in @(Get-FrontendJavaScriptFiles $ResourcesPath)) {
+        $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
+        if (-not $text.Contains("__claudeZhLabelPatch")) {
+            continue
+        }
+        $languageArrays = Update-LanguageArraysInText $text $Lang
+        if ([int]$languageArrays["AlreadyCount"] -gt 0) {
+            $relativePaths += Get-RelativeResourcePath $ResourcesPath $file.FullName
+        }
+    }
+    return @($relativePaths | Sort-Object -Unique)
+}
+
+function Get-RelativeFileFingerprints {
+    param(
+        [string]$ResourcesPath,
+        [object[]]$RelativePaths
+    )
+
+    $resourceRoot = [System.IO.Path]::GetFullPath($ResourcesPath).TrimEnd('\', '/')
+    $fingerprints = @()
+    foreach ($relativeValue in @($RelativePaths)) {
+        $relativePath = [string]$relativeValue
+        $bundlePath = [System.IO.Path]::GetFullPath((Join-Path $ResourcesPath $relativePath))
+        if (-not $bundlePath.StartsWith($resourceRoot + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "marker 资源路径越界: $relativePath"
+        }
+        Require-File $bundlePath
+        $item = Get-Item -LiteralPath $bundlePath
+        $fingerprints += [ordered]@{
+            path = $relativePath
+            length = [int64]$item.Length
+            sha256 = Get-FileSha256HexFromPath $bundlePath
+        }
+    }
+    return $fingerprints
+}
+
+function Get-BackedUpResourceRelativePaths {
+    param([string]$BackupSetPath)
+
+    if (-not (Test-Path -LiteralPath $BackupSetPath -PathType Container)) {
+        throw "marker 写入前备份集已丢失: $BackupSetPath"
+    }
+    $backupRoot = [System.IO.Path]::GetFullPath($BackupSetPath).TrimEnd('\', '/')
+    $relativePaths = @()
+    foreach ($file in @(Get-ChildItem -LiteralPath $BackupSetPath -File -Recurse -ErrorAction Stop)) {
+        $relativePath = $file.FullName.Substring($backupRoot.Length).TrimStart('\', '/')
+        if ($relativePath.StartsWith("_app\", [System.StringComparison]::OrdinalIgnoreCase)) {
+            continue
+        }
+        $relativePaths += $relativePath
+    }
+    return @($relativePaths | Sort-Object -Unique)
+}
+
+function Write-PatchMarker {
+    param(
+        [string]$ResourcesPath,
+        [hashtable]$Paths,
+        [string]$Lang,
+        [string]$Mode
+    )
+
+    if (-not $script:CurrentBackupSetPath) {
+        throw "无法写入 marker：本次安装没有备份集。"
+    }
+    $frontendBundleFiles = @(Get-PatchedFrontendBundleRelativePaths $ResourcesPath $Lang)
+    if ($frontendBundleFiles.Count -eq 0) {
+        throw "无法写入 marker：没有找到已注册中文且带显示名补丁的前端 bundle。"
+    }
+    $i18nDir = Get-FrontendI18nDirectory $ResourcesPath
+    $localeResourceFiles = @(
+        (Get-RelativeResourcePath $ResourcesPath (Join-Path $i18nDir "$Lang.json")),
+        (Get-RelativeResourcePath $ResourcesPath (Join-Path $i18nDir "statsig\$Lang.json")),
+        (Get-RelativeResourcePath $ResourcesPath (Join-Path $ResourcesPath "$Lang.json"))
+    )
+    $localeResourceLookup = @{}
+    foreach ($localeResourceFile in $localeResourceFiles) {
+        $localeResourceLookup[[string]$localeResourceFile] = $true
+    }
+    $modifiedResourceFiles = @(Get-BackedUpResourceRelativePaths $script:CurrentBackupSetPath |
+        Where-Object { -not $localeResourceLookup.ContainsKey([string]$_) })
+    if ($modifiedResourceFiles.Count -eq 0) {
+        throw "无法写入 marker：备份集中没有任何被修改的资源。"
+    }
+    $marker = [ordered]@{
+        schemaVersion = 2
+        patchVersion = Get-PatchReleaseVersion
+        installedAt = [DateTimeOffset]::UtcNow.ToString("o")
+        language = $Lang
+        mode = $Mode
+        backupSet = Split-Path -Leaf $script:CurrentBackupSetPath
+        createdFiles = @($script:InstallTransactionCreatedFiles)
+        frontendBundleFiles = $frontendBundleFiles
+        frontendBundleFingerprints = @(Get-RelativeFileFingerprints $ResourcesPath $frontendBundleFiles)
+        localeResourceFingerprints = @(Get-RelativeFileFingerprints $ResourcesPath $localeResourceFiles)
+        modifiedResourceFingerprints = @(Get-RelativeFileFingerprints $ResourcesPath $modifiedResourceFiles)
+        appIdentity = Get-ClaudeAppIdentity $Paths
+        patchedFingerprint = Get-WindowsMaintenanceFingerprint $Paths
+    }
+    $path = Get-PatchMarkerPath $ResourcesPath
+    $temporaryPath = "$path.tmp-$PID"
+    try {
+        Save-JsonNoBom $temporaryPath $marker 20
+        Move-Item -LiteralPath $temporaryPath -Destination $path -Force
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+    Write-Host "  wrote patch marker: $path" -ForegroundColor DarkGray
+}
+
 function New-BackupSet {
     param([string]$ResourcesPath)
 
@@ -466,15 +932,6 @@ function New-BackupSet {
     }
 
     $root = Get-BackupRoot $ResourcesPath
-    $existing = Get-ChildItem $root -Directory -ErrorAction SilentlyContinue |
-        Sort-Object Name |
-        Select-Object -First 1
-    if ($existing) {
-        $script:CurrentBackupSetPath = $existing.FullName
-        Write-Host "  backup set already exists, reusing oldest: $($existing.FullName)" -ForegroundColor DarkGray
-        return $script:CurrentBackupSetPath
-    }
-
     $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
     $path = Join-Path $root $stamp
     $suffix = 0
@@ -487,6 +944,32 @@ function New-BackupSet {
     $script:CurrentBackupSetPath = $path
     Write-Host "  backup set: $path" -ForegroundColor DarkGray
     return $path
+}
+
+function Register-InstallCreatedFile {
+    param(
+        [string]$ResourcesPath,
+        [string]$FilePath
+    )
+
+    $relative = Get-RelativeResourcePath $ResourcesPath $FilePath
+    if (-not $script:InstallTransactionCreatedFiles.Contains($relative)) {
+        $script:InstallTransactionCreatedFiles.Add($relative)
+    }
+}
+
+function Prepare-ManagedResourceFile {
+    param(
+        [string]$ResourcesPath,
+        [string]$FilePath
+    )
+
+    if (Test-Path -LiteralPath $FilePath) {
+        Backup-ModifiedFile $ResourcesPath $FilePath
+    }
+    else {
+        Register-InstallCreatedFile $ResourcesPath $FilePath
+    }
 }
 
 function Get-RelativeResourcePath {
@@ -557,26 +1040,32 @@ function Backup-AppFile {
     Write-Host "  backed up: app\$relative" -ForegroundColor DarkGray
 }
 
-function Restore-LatestBackup {
-    param([string]$ResourcesPath)
+function Resolve-MarkerBackupSetPath {
+    param(
+        [string]$ResourcesPath,
+        [object]$Marker
+    )
 
-    $root = Get-BackupRoot $ResourcesPath
-    if (-not (Test-Path $root)) {
-        Write-Host "  no zh-CN backup found; skipping bundle restore" -ForegroundColor DarkYellow
-        return
+    $name = ([string]$Marker.backupSet).Trim()
+    if (-not $name -or [System.IO.Path]::GetFileName($name) -ne $name) {
+        throw "marker 中的备份集名称无效。"
+    }
+    return Join-Path (Get-BackupRoot $ResourcesPath) $name
+}
+
+function Restore-BackupSet {
+    param(
+        [string]$ResourcesPath,
+        [string]$BackupSetPath
+    )
+
+    if (-not (Test-Path -LiteralPath $BackupSetPath -PathType Container)) {
+        throw "marker 指向的备份集不存在: $BackupSetPath"
     }
 
-    $backup = Get-ChildItem $root -Directory -ErrorAction SilentlyContinue |
-        Sort-Object Name |
-        Select-Object -First 1
-    if (-not $backup) {
-        Write-Host "  no zh-CN backup found; skipping bundle restore" -ForegroundColor DarkYellow
-        return
-    }
-
-    Write-Host "  restoring oldest backup set: $($backup.FullName)" -ForegroundColor DarkGray
-    $backupRoot = $backup.FullName.TrimEnd('\', '/')
-    $files = @(Get-ChildItem $backup.FullName -File -Recurse -ErrorAction SilentlyContinue)
+    Write-Host "  restoring marker backup set: $BackupSetPath" -ForegroundColor DarkGray
+    $backupRoot = [System.IO.Path]::GetFullPath($BackupSetPath).TrimEnd('\', '/')
+    $files = @(Get-ChildItem -LiteralPath $BackupSetPath -File -Recurse -ErrorAction Stop)
     foreach ($file in $files) {
         $relative = $file.FullName.Substring($backupRoot.Length).TrimStart('\', '/')
         if ($relative.StartsWith("_app\", [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -591,6 +1080,117 @@ function Restore-LatestBackup {
         Copy-Item $file.FullName $target -Force
         Write-Host "  restored: $relative" -ForegroundColor Green
     }
+    return $true
+}
+
+function Remove-CreatedResourceFiles {
+    param(
+        [string]$ResourcesPath,
+        [object[]]$RelativePaths
+    )
+
+    $resourceRoot = [System.IO.Path]::GetFullPath($ResourcesPath).TrimEnd('\', '/')
+    foreach ($relativeValue in @($RelativePaths)) {
+        $relative = [string]$relativeValue
+        if (-not $relative) {
+            continue
+        }
+        $target = [System.IO.Path]::GetFullPath((Join-Path $ResourcesPath $relative))
+        if (-not $target.StartsWith($resourceRoot + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Host "  [警告] 跳过 marker 中越界的新增文件路径: $relative" -ForegroundColor DarkYellow
+            continue
+        }
+        if (Test-Path -LiteralPath $target) {
+            Remove-Item -LiteralPath $target -Force -ErrorAction Stop
+            Write-Host "  removed patch-created file: $relative" -ForegroundColor Green
+        }
+    }
+}
+
+function Remove-BackupSetAfterRestore {
+    param(
+        [string]$ResourcesPath,
+        [string]$BackupSetPath
+    )
+
+    if (Test-Path -LiteralPath $BackupSetPath) {
+        Remove-Item -LiteralPath $BackupSetPath -Recurse -Force
+    }
+    $root = Get-BackupRoot $ResourcesPath
+    if ((Test-Path -LiteralPath $root) -and -not (Get-ChildItem -LiteralPath $root -Force -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+        Remove-Item -LiteralPath $root -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Start-InstallTransaction {
+    param([string]$ResourcesPath)
+
+    $pendingPath = Get-WindowsPendingRestorePath $ResourcesPath
+    if (Test-Path -LiteralPath $pendingPath -PathType Leaf) {
+        throw "发现未完成的精确备份恢复状态，拒绝新建安装事务。请先完成卸载/维护续作: $pendingPath"
+    }
+    $markerPath = Get-PatchMarkerPath $ResourcesPath
+    if (Test-Path -LiteralPath $markerPath) {
+        throw "安装前仍存在 patch marker，拒绝创建可能跨版本的备份。"
+    }
+    $orphanedRoot = Get-BackupRoot $ResourcesPath
+    if (Test-Path -LiteralPath $orphanedRoot) {
+        $orphanedItem = Get-ChildItem -LiteralPath $orphanedRoot -Force -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($orphanedItem) {
+            throw "发现没有 marker 的未决备份，可能来自一次未完整回滚；为避免删除唯一恢复源，已停止安装: $orphanedRoot"
+        }
+        Remove-Item -LiteralPath $orphanedRoot -Force -ErrorAction SilentlyContinue
+    }
+
+    $script:CurrentBackupSetPath = $null
+    $script:InstallTransactionCreatedFiles = [System.Collections.Generic.List[string]]::new()
+    $script:InstallTransactionResourcesPath = $ResourcesPath
+    $script:InstallTransactionActive = $true
+    $script:LastInstallRollbackSucceeded = $false
+    [void](New-BackupSet $ResourcesPath)
+}
+
+function Complete-InstallTransaction {
+    $script:InstallTransactionActive = $false
+    $script:InstallTransactionResourcesPath = $null
+    $script:LastInstallRollbackSucceeded = $true
+}
+
+function Rollback-InstallTransaction {
+    param([string]$ResourcesPath)
+
+    if (-not $script:InstallTransactionActive) {
+        $script:LastInstallRollbackSucceeded = $true
+        return $true
+    }
+    Write-Host "  正在自动回滚本次安装..." -ForegroundColor Yellow
+    $rollbackSucceeded = $false
+    try {
+        if (-not $script:CurrentBackupSetPath -or -not (Test-Path -LiteralPath $script:CurrentBackupSetPath -PathType Container)) {
+            throw "本次事务的备份集已丢失，无法确认回滚完成。"
+        }
+        [void](Restore-BackupSet $ResourcesPath $script:CurrentBackupSetPath)
+        Remove-CreatedResourceFiles $ResourcesPath @($script:InstallTransactionCreatedFiles)
+        Remove-Item -LiteralPath (Get-PatchMarkerPath $ResourcesPath) -Force -ErrorAction SilentlyContinue
+        if ($script:CurrentBackupSetPath) {
+            Remove-BackupSetAfterRestore $ResourcesPath $script:CurrentBackupSetPath
+        }
+        $rollbackSucceeded = $true
+        Write-Host "  本次文件改动已回滚。" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [警告] 自动回滚未完全成功: $($_.Exception.Message)" -ForegroundColor Red
+    }
+    finally {
+        $script:InstallTransactionActive = $false
+        $script:InstallTransactionResourcesPath = $null
+        if ($rollbackSucceeded) {
+            $script:CurrentBackupSetPath = $null
+        }
+        $script:InstallTransactionCreatedFiles = [System.Collections.Generic.List[string]]::new()
+        $script:LastInstallRollbackSucceeded = $rollbackSucceeded
+    }
+    return $rollbackSucceeded
 }
 
 function Get-LanguageResources {
@@ -616,15 +1216,21 @@ function Get-LanguageResources {
 function Enable-WriteAccess {
     param([string]$ResourcesPath)
 
+    $i18nDir = Get-FrontendI18nDirectory $ResourcesPath
     $paths = @(
         (Get-ClaudeAppPathFromResources $ResourcesPath),
         $ResourcesPath,
         (Join-Path $ResourcesPath "ion-dist"),
-        (Join-Path $ResourcesPath "ion-dist\i18n"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\statsig"),
-        (Join-Path $ResourcesPath "ion-dist\assets"),
-        (Join-Path $ResourcesPath "ion-dist\assets\v1")
+        $i18nDir,
+        (Join-Path $i18nDir "statsig"),
+        (Join-Path $ResourcesPath "ion-dist\assets")
     )
+
+    $assetsRoot = Join-Path $ResourcesPath "ion-dist\assets"
+    if (Test-Path -LiteralPath $assetsRoot -PathType Container) {
+        $paths += @(Get-ChildItem -LiteralPath $assetsRoot -Directory -Recurse -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName })
+    }
 
     foreach ($path in $paths) {
         Grant-WriteAccess $path
@@ -638,19 +1244,48 @@ function Install-LanguageFiles {
         [string]$Lang
     )
 
-    $i18nDir = Join-Path $ResourcesPath "ion-dist\i18n"
+    $i18nDir = Get-FrontendI18nDirectory $ResourcesPath
     $statsigDir = Join-Path $i18nDir "statsig"
     New-Item -ItemType Directory -Path $i18nDir -Force | Out-Null
     New-Item -ItemType Directory -Path $statsigDir -Force | Out-Null
 
-    Copy-Item $Pack["Frontend"] (Join-Path $i18nDir "$Lang.json") -Force
-    Write-Host "  installed ion-dist/i18n/$Lang.json" -ForegroundColor Green
+    $englishPath = Join-Path $i18nDir "en-US.json"
+    Require-File $englishPath
+    $english = Get-Content -LiteralPath $englishPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $translations = Get-Content -LiteralPath $Pack["Frontend"] -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not $english -or -not $translations) {
+        throw "Unsupported frontend i18n JSON shape."
+    }
 
-    Copy-Item $Pack["Desktop"] (Join-Path $ResourcesPath "$Lang.json") -Force
+    $merged = [ordered]@{}
+    $translatedCount = 0
+    $fallbackCount = 0
+    foreach ($property in $english.PSObject.Properties) {
+        $translationProperty = $translations.PSObject.Properties[$property.Name]
+        if ($null -ne $translationProperty) {
+            $merged[$property.Name] = $translationProperty.Value
+            $translatedCount += 1
+        }
+        else {
+            $merged[$property.Name] = $property.Value
+            $fallbackCount += 1
+        }
+    }
+
+    $frontendTarget = Join-Path $i18nDir "$Lang.json"
+    Prepare-ManagedResourceFile $ResourcesPath $frontendTarget
+    Save-JsonNoBom $frontendTarget $merged 100
+    Write-Host "  installed frontend locale $Lang.json ($translatedCount translated, $fallbackCount English fallback): $i18nDir" -ForegroundColor Green
+
+    $desktopTarget = Join-Path $ResourcesPath "$Lang.json"
+    Prepare-ManagedResourceFile $ResourcesPath $desktopTarget
+    Copy-Item -LiteralPath $Pack["Desktop"] -Destination $desktopTarget -Force
     Write-Host "  installed resources/$Lang.json" -ForegroundColor Green
 
-    Copy-Item $Pack["Statsig"] (Join-Path $statsigDir "$Lang.json") -Force
-    Write-Host "  installed ion-dist/i18n/statsig/$Lang.json" -ForegroundColor Green
+    $statsigTarget = Join-Path $statsigDir "$Lang.json"
+    Prepare-ManagedResourceFile $ResourcesPath $statsigTarget
+    Copy-Item -LiteralPath $Pack["Statsig"] -Destination $statsigTarget -Force
+    Write-Host "  installed statsig locale $Lang.json" -ForegroundColor Green
 }
 
 function Align-4 {
@@ -962,8 +1597,22 @@ function Replace-AsarFileContent {
     $entry.size = $PatchedContent.Length
     $entry.integrity = Get-AsarFileIntegrity $PatchedContent
     if ($delta -ne 0) {
-        foreach ($other in Get-AsarFileEntries $header) {
-            if ((-not [object]::ReferenceEquals($other, $entry)) -and ([int64]$other.offset -gt $targetOffset)) {
+        $orderedEntries = @(Get-AsarFileEntries $header)
+        $targetIndex = -1
+        for ($index = 0; $index -lt $orderedEntries.Count; $index++) {
+            if ([object]::ReferenceEquals($orderedEntries[$index], $entry)) {
+                $targetIndex = $index
+                break
+            }
+        }
+        if ($targetIndex -lt 0) {
+            throw "Internal patch error: lost ASAR entry for $FilePath."
+        }
+        for ($index = $targetIndex + 1; $index -lt $orderedEntries.Count; $index++) {
+            $other = $orderedEntries[$index]
+            if ([int64]$other.offset -ge $targetOffset) {
+                # Empty ASAR entries can share the following file's offset;
+                # header order determines which later entries must move.
                 Set-AsarEntryOffset $other ([int64]$other.offset + $delta)
             }
         }
@@ -1155,52 +1804,45 @@ function Register-Language {
         [string]$Lang
     )
 
-    $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
-    if ($jsFiles.Count -eq 0) {
-        throw "未找到前端 JS bundle: $assetsDir"
-    }
-
-    $regex = [System.Text.RegularExpressions.Regex]::new($LanguageListPattern)
-    $replacement = "$BaseLanguageList,`"$Lang`"]"
+    $jsFiles = @(Get-FrontendJavaScriptFiles $ResourcesPath)
     $changed = 0
     $already = 0
+    $candidates = 0
     foreach ($file in $jsFiles) {
         $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
-        if ($text.Contains($replacement)) {
-            Write-Host "  $Lang already registered: $($file.Name)" -ForegroundColor Green
-            $already += 1
-            continue
-        }
-
-        if ($regex.IsMatch($text)) {
-            $updated = $regex.Replace($text, $replacement, 1)
+        $result = Update-LanguageArraysInText $text $Lang
+        $candidates += [int]$result["CandidateCount"]
+        $already += [int]$result["AlreadyCount"]
+        if ([int]$result["ChangedCount"] -gt 0) {
             Backup-ModifiedFile $ResourcesPath $file.FullName
-            [System.IO.File]::WriteAllText($file.FullName, $updated, $Utf8NoBom)
+            [System.IO.File]::WriteAllText($file.FullName, [string]$result["Text"], $Utf8NoBom)
             Write-Host "  patched language whitelist for ${Lang}: $($file.Name)" -ForegroundColor Green
-            $changed += 1
+            $changed += [int]$result["ChangedCount"]
         }
     }
 
-    if (($changed + $already) -eq 0) {
+    if ($candidates -eq 0) {
         throw "未能注册中文语言，Claude 前端 bundle 格式可能已经变化。"
+    }
+    if ($changed -eq 0 -and $already -gt 0) {
+        Write-Host "  $Lang already registered in upstream language list" -ForegroundColor Green
     }
 }
 
 function Patch-LanguageDisplayNames {
     param([string]$ResourcesPath)
 
-    $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
-    if ($jsFiles.Count -eq 0) {
-        throw "未找到前端 JS bundle: $assetsDir"
-    }
+    $jsFiles = @(Get-FrontendJavaScriptFiles $ResourcesPath)
 
     $marker = "__claudeZhLabelPatch"
     $patch = ';(()=>{const e=Intl.DisplayNames&&Intl.DisplayNames.prototype;if(!e||e.__claudeZhLabelPatch)return;const n=e.of;e.of=function(e){const t=String(e);return t==="zh-CN"?"简体中文":t==="zh-HK"?"繁体中文（中国香港）":t==="zh-TW"?"繁体中文（中国台湾）":n.call(this,e)},Object.defineProperty(e,"__claudeZhLabelPatch",{value:!0})})();'
     $patchedFiles = 0
     foreach ($file in $jsFiles) {
         $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
+        $languageArrays = Update-LanguageArraysInText $text $LanguageCode
+        if ([int]$languageArrays["CandidateCount"] -eq 0) {
+            continue
+        }
         if ($text.Contains($marker)) {
             Write-Host "  language display names already patched: $($file.Name)" -ForegroundColor Green
             continue
@@ -1220,15 +1862,16 @@ function Patch-LanguageDisplayNames {
 function Unregister-Language {
     param([string]$ResourcesPath)
 
-    $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
+    $jsFiles = @(Get-FrontendJavaScriptFiles $ResourcesPath)
     foreach ($file in $jsFiles) {
         $text = [System.IO.File]::ReadAllText($file.FullName, [System.Text.Encoding]::UTF8)
         $updated = $text
         $changed = $false
-        foreach ($lang in @(',"zh-CN"', ',"zh-TW"', ',"zh-HK"')) {
-            if ($updated.Contains($lang)) {
-                $updated = $updated.Replace($lang, '')
+        foreach ($lang in @("zh-CN", "zh-TW", "zh-HK")) {
+            $pattern = '(?<separator>\s*,\s*)["'']' + [System.Text.RegularExpressions.Regex]::Escape($lang) + '["'']'
+            $next = [System.Text.RegularExpressions.Regex]::Replace($updated, $pattern, '')
+            if ($next -ne $updated) {
+                $updated = $next
                 $changed = $true
             }
         }
@@ -1377,7 +2020,7 @@ function Get-OnlineTranslationMap {
         [string]$Language
     )
 
-    $enPath = Join-Path $ResourcesPath "ion-dist\i18n\en-US.json"
+    $enPath = Join-Path (Get-FrontendI18nDirectory $ResourcesPath) "en-US.json"
     Require-File $enPath
     Require-File $Pack["Frontend"]
 
@@ -1806,11 +2449,7 @@ function Patch-HardcodedFrontendStrings {
         [string]$Language
     )
 
-    $assetsDir = Join-Path $ResourcesPath "ion-dist\assets\v1"
-    $jsFiles = @(Get-ChildItem (Join-Path $assetsDir "*.js") -ErrorAction SilentlyContinue)
-    if ($jsFiles.Count -eq 0) {
-        throw "未找到前端 JS bundle: $assetsDir"
-    }
+    $jsFiles = @(Get-FrontendJavaScriptFiles $ResourcesPath)
 
     $replacements = @(Get-FrontendHardcodedReplacements $Language)
     $patchedFiles = 0
@@ -2536,11 +3175,6 @@ function Patch-ModelPickerStrings {
 function Set-ClaudeLocale {
     param([string]$Locale)
 
-    if (-not $env:LOCALAPPDATA) {
-        Write-Host "  [警告] LOCALAPPDATA 未设置，跳过用户配置。" -ForegroundColor DarkYellow
-        return
-    }
-
     $configPaths = Get-ClaudeConfigPaths
     if ($configPaths.Count -eq 0) {
         Write-Host "  [警告] 未找到 Claude 用户配置目录，跳过用户配置。" -ForegroundColor DarkYellow
@@ -2799,6 +3433,733 @@ function Set-ClaudeAutoUpdates {
         Write-Host "允许更新成功" -ForegroundColor Green
     } else {
         Write-Host "禁止更新成功" -ForegroundColor Green
+    }
+}
+
+function Get-WindowsMaintenanceRoot {
+    $programData = [Environment]::GetFolderPath('CommonApplicationData')
+    if (-not $programData) {
+        throw "无法定位 ProgramData，不能安装自动维护任务。"
+    }
+    return Join-Path $programData "ClaudeDesktopZhCn"
+}
+
+function Get-WindowsMaintenanceTaskName {
+    return "ClaudeDesktopZhCnMaintain"
+}
+
+function Test-PathIsReparsePoint {
+    param([string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $false
+    }
+    $item = Get-Item -LiteralPath $Path -Force
+    return (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0)
+}
+
+function Set-WindowsMaintenanceAcl {
+    param([string]$Root)
+
+    if (Test-PathIsReparsePoint $Root) {
+        throw "拒绝使用 reparse point 作为维护目录: $Root"
+    }
+    $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $acl.SetAccessRuleProtection($true, $false)
+    $inheritance = [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+        [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+    $propagation = [System.Security.AccessControl.PropagationFlags]::None
+    $allow = [System.Security.AccessControl.AccessControlType]::Allow
+    foreach ($sidValue in @("S-1-5-18", "S-1-5-32-544")) {
+        $sid = [System.Security.Principal.SecurityIdentifier]::new($sidValue)
+        $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+            $sid,
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            $inheritance,
+            $propagation,
+            $allow
+        )
+        [void]$acl.AddAccessRule($rule)
+    }
+    Set-Acl -LiteralPath $Root -AclObject $acl
+}
+
+function Disable-WindowsMaintenanceTask {
+    try {
+        $taskName = Get-WindowsMaintenanceTaskName
+        $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+        if ($task) {
+            Disable-ScheduledTask -TaskName $taskName -ErrorAction Stop | Out-Null
+        }
+    }
+    catch {
+        Write-Host "  [警告] 无法禁用自动维护任务: $($_.Exception.Message)" -ForegroundColor DarkYellow
+    }
+}
+
+function Test-WindowsMaintenanceTaskEnabled {
+    try {
+        $task = Get-ScheduledTask -TaskName (Get-WindowsMaintenanceTaskName) -ErrorAction SilentlyContinue
+        return [bool]($task -and [string]$task.State -ne "Disabled")
+    }
+    catch {
+        return $false
+    }
+}
+
+function Enable-WindowsMaintenanceTask {
+    try {
+        $taskName = Get-WindowsMaintenanceTaskName
+        $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+        if ($task) {
+            Enable-ScheduledTask -TaskName $taskName -ErrorAction Stop | Out-Null
+        }
+    }
+    catch {
+        Write-Host "  [警告] 无法重新启用原自动维护任务: $($_.Exception.Message)" -ForegroundColor DarkYellow
+    }
+}
+
+function Remove-WindowsMaintenanceTask {
+    try {
+        $taskName = Get-WindowsMaintenanceTaskName
+        $task = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+        if ($task) {
+            Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction Stop
+            Write-Host "  removed maintenance task: $taskName" -ForegroundColor Green
+        }
+    }
+    catch {
+        Write-Host "  [警告] 无法删除自动维护任务: $($_.Exception.Message)" -ForegroundColor DarkYellow
+    }
+}
+
+function Install-WindowsMaintenanceTask {
+    param(
+        [string]$Language,
+        [string]$Mode
+    )
+
+    if ($script:IsMaintenanceRun) {
+        return
+    }
+
+    $root = Get-WindowsMaintenanceRoot
+    if ((Test-Path -LiteralPath $root) -and (Test-PathIsReparsePoint $root)) {
+        throw "拒绝覆盖 reparse point 维护目录: $root"
+    }
+    Disable-WindowsMaintenanceTask
+    if (Test-Path -LiteralPath $root) {
+        Remove-Item -LiteralPath $root -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    Set-WindowsMaintenanceAcl $root
+
+    $payloadRoot = Join-Path $root "payload"
+    $payloadScripts = Join-Path $payloadRoot "scripts"
+    $payloadResources = Join-Path $payloadRoot "resources"
+    New-Item -ItemType Directory -Path $payloadScripts -Force | Out-Null
+    New-Item -ItemType Directory -Path $payloadResources -Force | Out-Null
+
+    $sourceScript = Join-Path $PSScriptRoot "install_windows.ps1"
+    $sourceProject = Split-Path -Parent (Split-Path -Parent $sourceScript)
+    $sourceResources = Join-Path $sourceProject "resources"
+    Require-File $sourceScript
+    if (-not (Test-Path -LiteralPath $sourceResources -PathType Container)) {
+        throw "缺少维护 payload resources: $sourceResources"
+    }
+    Copy-Item -LiteralPath $sourceScript -Destination (Join-Path $payloadScripts "install_windows.ps1") -Force
+    Copy-Item -Path (Join-Path $sourceResources "*") -Destination $payloadResources -Recurse -Force
+
+    $targetUserSid = if ($env:CLAUDE_ZH_ORIGINAL_USER_SID) {
+        [string]$env:CLAUDE_ZH_ORIGINAL_USER_SID
+    } else {
+        [string]([System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value)
+    }
+    $targetUserProfile = if ($env:CLAUDE_ZH_ORIGINAL_USER_PROFILE) { [string]$env:CLAUDE_ZH_ORIGINAL_USER_PROFILE } else { [string]$env:USERPROFILE }
+    $targetAppData = if ($env:CLAUDE_ZH_ORIGINAL_APPDATA) { [string]$env:CLAUDE_ZH_ORIGINAL_APPDATA } else { [string]$env:APPDATA }
+    $targetLocalAppData = if ($env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA) { [string]$env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA } else { [string]$env:LOCALAPPDATA }
+    $config = [ordered]@{
+        schemaVersion = 1
+        language = $Language
+        patchMode = $Mode
+        originalUserSid = $targetUserSid
+        originalUserProfile = $targetUserProfile
+        originalAppData = $targetAppData
+        originalLocalAppData = $targetLocalAppData
+        installedAt = [DateTimeOffset]::UtcNow.ToString("o")
+    }
+    Save-JsonNoBom (Join-Path $root "config.json") $config 10
+    Set-WindowsMaintenanceAcl $root
+
+    $powershellExe = Join-Path $env:SystemRoot "System32\WindowsPowerShell\v1.0\powershell.exe"
+    Require-File $powershellExe
+    $payloadScript = Join-Path $payloadScripts "install_windows.ps1"
+    $arguments = "-NoLogo -NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$payloadScript`" -Action maintain"
+    $action = New-ScheduledTaskAction -Execute $powershellExe -Argument $arguments
+    $startupTrigger = New-ScheduledTaskTrigger -AtStartup
+    $repeatTrigger = New-ScheduledTaskTrigger `
+        -Once `
+        -At (Get-Date).AddMinutes(10) `
+        -RepetitionInterval (New-TimeSpan -Minutes 15) `
+        -RepetitionDuration (New-TimeSpan -Days 3650)
+    $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -LogonType ServiceAccount -RunLevel Highest
+    $settings = New-ScheduledTaskSettingsSet `
+        -MultipleInstances IgnoreNew `
+        -StartWhenAvailable `
+        -ExecutionTimeLimit (New-TimeSpan -Minutes 15) `
+        -AllowStartIfOnBatteries `
+        -DontStopIfGoingOnBatteries
+    $task = New-ScheduledTask `
+        -Action $action `
+        -Trigger @($startupTrigger, $repeatTrigger) `
+        -Principal $principal `
+        -Settings $settings `
+        -Description "Reapply Claude Desktop Chinese resources after an official app update."
+    Register-ScheduledTask -TaskName (Get-WindowsMaintenanceTaskName) -InputObject $task -Force | Out-Null
+    Write-Host "  installed automatic maintenance task (ProgramData payload, SYSTEM/admin-only)" -ForegroundColor Green
+}
+
+function Get-WindowsMaintenanceCriticalPaths {
+    param([hashtable]$Paths)
+
+    $exePath = Get-ClaudeExePath ([string]$Paths["App"])
+    if (-not $exePath) {
+        throw "Claude.exe 尚未准备完成。"
+    }
+    $asarPath = Join-Path ([string]$Paths["Resources"]) "app.asar"
+    Require-File $exePath
+    Require-File $asarPath
+
+    $i18nDir = Get-FrontendI18nDirectory ([string]$Paths["Resources"])
+    $englishPath = Join-Path $i18nDir "en-US.json"
+    Require-File $englishPath
+    $javascriptFiles = @(Get-FrontendJavaScriptFiles ([string]$Paths["Resources"]))
+    if ($javascriptFiles.Count -eq 0) {
+        throw "前端 JavaScript bundle 尚未准备完成。"
+    }
+
+    $criticalPaths = @($exePath, $asarPath, $englishPath)
+    $criticalPaths += @($javascriptFiles | ForEach-Object { $_.FullName })
+    return @($criticalPaths | Where-Object { $_ } | Sort-Object -Unique)
+}
+
+function Test-WindowsMaintenanceReady {
+    param([hashtable]$Paths)
+
+    if (@(Get-ClaudeDesktopProcesses).Count -gt 0 -or @(Get-ClaudeCoworkProcesses).Count -gt 0) {
+        Write-Host "  Claude 正在运行，维护任务延后。" -ForegroundColor DarkYellow
+        return $false
+    }
+    try {
+        $criticalPaths = @(Get-WindowsMaintenanceCriticalPaths $Paths)
+    }
+    catch {
+        Write-Host "  Claude 更新资源尚未准备完成，维护任务延后: $($_.Exception.Message)" -ForegroundColor DarkYellow
+        return $false
+    }
+
+    $cutoff = (Get-Date).ToUniversalTime().AddSeconds(-$WindowsMaintenanceSettleSeconds)
+    foreach ($criticalPath in $criticalPaths) {
+        if (-not (Test-Path -LiteralPath $criticalPath -PathType Leaf)) {
+            Write-Host "  Claude 更新文件尚未出现，维护任务延后: $criticalPath" -ForegroundColor DarkYellow
+            return $false
+        }
+        $item = Get-Item -LiteralPath $criticalPath
+        if ($item.LastWriteTimeUtc -gt $cutoff -or $item.CreationTimeUtc -gt $cutoff) {
+            Write-Host "  Claude 更新文件仍可能写入中，维护任务延后: $criticalPath" -ForegroundColor DarkYellow
+            return $false
+        }
+    }
+    return $true
+}
+
+function Get-WindowsMaintenanceFingerprint {
+    param([hashtable]$Paths)
+
+    $discoveryError = ""
+    try {
+        $criticalPaths = @(Get-WindowsMaintenanceCriticalPaths $Paths)
+    }
+    catch {
+        $discoveryError = $_.Exception.Message
+        $criticalPaths = @(
+            (Get-ClaudeExePath ([string]$Paths["App"])),
+            (Join-Path ([string]$Paths["Resources"]) "app.asar")
+        )
+    }
+
+    $files = @()
+    $javascriptCount = 0
+    $javascriptTotalLength = [int64]0
+    $javascriptNewestWriteTicks = [int64]0
+    $javascriptNewestCreationTicks = [int64]0
+    foreach ($path in @($criticalPaths | Where-Object { $_ } | Sort-Object -Unique)) {
+        if ($path -and (Test-Path -LiteralPath $path -PathType Leaf)) {
+            $item = Get-Item -LiteralPath $path
+            if ($item.Extension -ieq ".js") {
+                $javascriptCount += 1
+                $javascriptTotalLength += [int64]$item.Length
+                $javascriptNewestWriteTicks = [Math]::Max($javascriptNewestWriteTicks, [int64]$item.LastWriteTimeUtc.Ticks)
+                $javascriptNewestCreationTicks = [Math]::Max($javascriptNewestCreationTicks, [int64]$item.CreationTimeUtc.Ticks)
+                continue
+            }
+            $files += [ordered]@{
+                path = [System.IO.Path]::GetFullPath($path)
+                length = [int64]$item.Length
+                lastWriteTimeUtcTicks = [int64]$item.LastWriteTimeUtc.Ticks
+                creationTimeUtcTicks = [int64]$item.CreationTimeUtc.Ticks
+                prefixSha256 = Get-FilePrefixSha256Hex $path
+            }
+        }
+    }
+    return [ordered]@{
+        appIdentity = Get-ClaudeAppIdentity $Paths
+        discoveryError = $discoveryError
+        files = $files
+        frontendJavaScript = [ordered]@{
+            count = $javascriptCount
+            totalLength = $javascriptTotalLength
+            newestWriteTimeUtcTicks = $javascriptNewestWriteTicks
+            newestCreationTimeUtcTicks = $javascriptNewestCreationTicks
+        }
+    }
+}
+
+function Test-PatchMarkerMatchesFingerprint {
+    param(
+        [object]$Marker,
+        [hashtable]$Paths
+    )
+
+    if (-not $Marker -or -not $Marker.patchedFingerprint) {
+        return $false
+    }
+    try {
+        $recordedFingerprint = $Marker.patchedFingerprint | ConvertTo-Json -Compress -Depth 30
+        $currentFingerprint = Get-WindowsMaintenanceFingerprint $Paths | ConvertTo-Json -Compress -Depth 30
+        if ($recordedFingerprint -ne $currentFingerprint) {
+            return $false
+        }
+        $bundleFiles = @($Marker.frontendBundleFiles)
+        $recordedBundles = @($Marker.frontendBundleFingerprints)
+        if ($bundleFiles.Count -eq 0 -or $recordedBundles.Count -eq 0) {
+            return $false
+        }
+        $currentBundles = @(Get-RelativeFileFingerprints ([string]$Paths["Resources"]) $bundleFiles)
+        $recordedBundleJson = $recordedBundles | ConvertTo-Json -Compress -Depth 10
+        $currentBundleJson = $currentBundles | ConvertTo-Json -Compress -Depth 10
+        if ($recordedBundleJson -ne $currentBundleJson) {
+            return $false
+        }
+        $recordedModified = @($Marker.modifiedResourceFingerprints)
+        if ($recordedModified.Count -eq 0) {
+            return $false
+        }
+        $modifiedFiles = @($recordedModified | ForEach-Object { [string]$_.path })
+        $currentModified = @(Get-RelativeFileFingerprints ([string]$Paths["Resources"]) $modifiedFiles)
+        $recordedModifiedJson = $recordedModified | ConvertTo-Json -Compress -Depth 10
+        $currentModifiedJson = $currentModified | ConvertTo-Json -Compress -Depth 10
+        return $recordedModifiedJson -eq $currentModifiedJson
+    }
+    catch {
+        return $false
+    }
+}
+
+function Test-WindowsPatchCurrent {
+    param(
+        [object]$Marker,
+        [hashtable]$Paths,
+        [string]$Language,
+        [string]$Mode
+    )
+
+    if (-not $Marker -or [int]$Marker.schemaVersion -ne 2) {
+        return $false
+    }
+    if ([string]$Marker.patchVersion -ne (Get-PatchReleaseVersion) -or
+        [string]$Marker.language -ne $Language -or
+        [string]$Marker.mode -ne $Mode -or
+        -not (Test-PatchMarkerMatchesIdentity $Marker $Paths) -or
+        -not (Test-PatchMarkerMatchesFingerprint $Marker $Paths)) {
+        return $false
+    }
+
+    try {
+        $resourcesPath = [string]$Paths["Resources"]
+        $backupSetPath = Resolve-MarkerBackupSetPath $resourcesPath $Marker
+        if (-not (Test-Path -LiteralPath $backupSetPath -PathType Container)) {
+            return $false
+        }
+        $frontendBundleFiles = @($Marker.frontendBundleFiles)
+        if ($frontendBundleFiles.Count -eq 0) {
+            return $false
+        }
+        $i18nDir = Get-FrontendI18nDirectory $resourcesPath
+        $requiredLocales = @(
+            (Join-Path $i18nDir "$Language.json"),
+            (Join-Path $i18nDir "statsig\$Language.json"),
+            (Join-Path $resourcesPath "$Language.json")
+        )
+        foreach ($localePath in $requiredLocales) {
+            if (-not (Test-Path -LiteralPath $localePath -PathType Leaf)) {
+                return $false
+            }
+            $locale = Get-Content -LiteralPath $localePath -Raw -Encoding UTF8 | ConvertFrom-Json
+            if (-not $locale -or $locale.PSObject.Properties.Count -eq 0) {
+                return $false
+            }
+        }
+        $recordedLocaleFingerprints = @($Marker.localeResourceFingerprints)
+        if ($recordedLocaleFingerprints.Count -ne $requiredLocales.Count) {
+            return $false
+        }
+        $recordedLocaleFiles = @($recordedLocaleFingerprints | ForEach-Object { [string]$_.path })
+        $currentLocaleFingerprints = @(Get-RelativeFileFingerprints $resourcesPath $recordedLocaleFiles)
+        $recordedLocaleJson = $recordedLocaleFingerprints | ConvertTo-Json -Compress -Depth 10
+        $currentLocaleJson = $currentLocaleFingerprints | ConvertTo-Json -Compress -Depth 10
+        if ($recordedLocaleJson -ne $currentLocaleJson) {
+            return $false
+        }
+
+        $registered = $false
+        $displayNamePatched = $false
+        $resourceRoot = [System.IO.Path]::GetFullPath($resourcesPath).TrimEnd('\', '/')
+        foreach ($relativeValue in $frontendBundleFiles) {
+            $relativePath = [string]$relativeValue
+            $bundlePath = [System.IO.Path]::GetFullPath((Join-Path $resourcesPath $relativePath))
+            if (-not $bundlePath.StartsWith($resourceRoot + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase) -or
+                -not (Test-Path -LiteralPath $bundlePath -PathType Leaf)) {
+                return $false
+            }
+            $text = [System.IO.File]::ReadAllText($bundlePath, [System.Text.Encoding]::UTF8)
+            $languageArrays = Update-LanguageArraysInText $text $Language
+            if ([int]$languageArrays["AlreadyCount"] -gt 0) {
+                $registered = $true
+                if ($text.Contains("__claudeZhLabelPatch")) {
+                    $displayNamePatched = $true
+                }
+            }
+        }
+        return ($registered -and $displayNamePatched)
+    }
+    catch {
+        return $false
+    }
+}
+
+function Read-WindowsPendingRestore {
+    param([string]$ResourcesPath)
+
+    $path = Get-WindowsPendingRestorePath $ResourcesPath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+        return $null
+    }
+    try {
+        $pending = Get-Content -LiteralPath $path -Raw -Encoding UTF8 | ConvertFrom-Json
+        if (-not $pending -or [int]$pending.schemaVersion -ne 1 -or -not $pending.marker) {
+            throw "pending restore 缺少 schemaVersion/marker"
+        }
+        if (-not ([string]$pending.resourcesPath).Trim()) {
+            throw "pending restore 缺少 resourcesPath"
+        }
+        if (-not ([string]$pending.marker.backupSet).Trim()) {
+            throw "pending restore marker 缺少 backupSet"
+        }
+        return $pending
+    }
+    catch {
+        Write-Host "  [警告] 待续作恢复状态无效，将忽略: $path ($($_.Exception.Message))" -ForegroundColor DarkYellow
+        return $null
+    }
+}
+
+function Write-WindowsPendingRestore {
+    param(
+        [string]$ResourcesPath,
+        [object]$Marker,
+        [hashtable]$Paths
+    )
+
+    if (-not $Marker -or -not ([string]$Marker.backupSet).Trim()) {
+        throw "无法写入待续作恢复状态：marker 缺少 backupSet。"
+    }
+    $backupSetPath = Resolve-MarkerBackupSetPath $ResourcesPath $Marker
+    if (-not (Test-Path -LiteralPath $backupSetPath -PathType Container)) {
+        throw "无法写入待续作恢复状态：备份集不存在: $backupSetPath"
+    }
+
+    $pending = [ordered]@{
+        schemaVersion = 1
+        createdAt = [DateTimeOffset]::UtcNow.ToString("o")
+        resourcesPath = [System.IO.Path]::GetFullPath($ResourcesPath)
+        appPath = [System.IO.Path]::GetFullPath([string]$Paths["App"])
+        marker = $Marker
+    }
+    $path = Get-WindowsPendingRestorePath $ResourcesPath
+    $temporaryPath = "$path.tmp-$PID"
+    try {
+        Save-JsonNoBom $temporaryPath $pending 30
+        Move-Item -LiteralPath $temporaryPath -Destination $path -Force
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+    Write-Host "  wrote resumable restore state: $path" -ForegroundColor DarkGray
+}
+
+function Clear-WindowsPendingRestore {
+    param([string]$ResourcesPath)
+
+    $path = Get-WindowsPendingRestorePath $ResourcesPath
+    if (Test-Path -LiteralPath $path -PathType Leaf) {
+        Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+        Write-Host "  cleared resumable restore state: $path" -ForegroundColor DarkGray
+    }
+}
+
+function Test-WindowsPendingRestoreMatchesCurrentApp {
+    param(
+        [object]$Pending,
+        [hashtable]$Paths
+    )
+
+    if (-not $Pending -or [int]$Pending.schemaVersion -ne 1 -or -not $Pending.marker) {
+        return $false
+    }
+    $resourcesPath = [System.IO.Path]::GetFullPath([string]$Paths["Resources"]).TrimEnd('\', '/')
+    $recordedResourcesPath = [System.IO.Path]::GetFullPath([string]$Pending.resourcesPath).TrimEnd('\', '/')
+    if (-not $resourcesPath.Equals($recordedResourcesPath, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $false
+    }
+    $current = Get-ClaudeAppIdentity $Paths
+    $recorded = $Pending.marker.appIdentity
+    if (-not $recorded) {
+        return $false
+    }
+    # Identity-only match: half-restored trees intentionally fail patched fingerprint checks.
+    foreach ($propertyName in @("appPath", "installKind", "fileVersion", "productVersion")) {
+        $expected = [string]$recorded.$propertyName
+        $actual = [string]$current.$propertyName
+        if ($propertyName -eq "appPath") {
+            if (-not $expected -or -not $actual.Equals($expected, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $false
+            }
+        }
+        elseif ($expected -and $actual -and $expected -ne $actual) {
+            return $false
+        }
+    }
+    try {
+        $backupSetPath = Resolve-MarkerBackupSetPath $resourcesPath $Pending.marker
+        return Test-Path -LiteralPath $backupSetPath -PathType Container
+    }
+    catch {
+        return $false
+    }
+}
+
+function Invoke-WindowsPendingRestore {
+    param(
+        [object]$Pending,
+        [hashtable]$Paths
+    )
+
+    if (-not (Test-WindowsPendingRestoreMatchesCurrentApp $Pending $Paths)) {
+        throw "待续作恢复状态与当前 Claude build 不匹配。"
+    }
+    $resourcesPath = [string]$Paths["Resources"]
+    $marker = $Pending.marker
+    $backupSetPath = Resolve-MarkerBackupSetPath $resourcesPath $marker
+    Write-Step "[恢复 1/3] 续作当前 build 的精确原版备份"
+    [void](Restore-BackupSet $resourcesPath $backupSetPath)
+
+    Write-Step "[恢复 2/3] 删除仅由补丁创建的资源"
+    Remove-CreatedResourceFiles $resourcesPath @($marker.createdFiles)
+
+    Write-Step "[恢复 3/3] 恢复用户语言配置"
+    try {
+        Set-ClaudeLocale "en-US"
+    }
+    catch {
+        Write-Host "  [警告] 原版文件已恢复，但无法自动写入 en-US 用户配置: $($_.Exception.Message)" -ForegroundColor DarkYellow
+    }
+
+    Remove-Item -LiteralPath (Get-PatchMarkerPath $resourcesPath) -Force -ErrorAction SilentlyContinue
+    Remove-BackupSetAfterRestore $resourcesPath $backupSetPath
+    Clear-WindowsPendingRestore $resourcesPath
+    $script:CurrentBackupSetPath = $null
+    Write-Host "  当前 build 的官方基线已完整恢复。" -ForegroundColor Green
+    return $true
+}
+
+function Invoke-WindowsMaintenanceLocked {
+    $root = Get-WindowsMaintenanceRoot
+    $configPath = Join-Path $root "config.json"
+    Require-File $configPath
+    $config = Get-Content -LiteralPath $configPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $maintenanceLanguage = [string]$config.language
+    $maintenanceMode = [string]$config.patchMode
+    if ($maintenanceLanguage -notin @("zh-CN", "zh-TW", "zh-HK")) {
+        throw "维护配置中的语言无效。"
+    }
+    if ($maintenanceMode -notin @("safe", "official")) {
+        throw "维护配置中的补丁模式无效。"
+    }
+
+    $env:CLAUDE_ZH_ORIGINAL_USER_SID = [string]$config.originalUserSid
+    $env:CLAUDE_ZH_ORIGINAL_USER_PROFILE = [string]$config.originalUserProfile
+    $env:CLAUDE_ZH_ORIGINAL_APPDATA = [string]$config.originalAppData
+    $env:CLAUDE_ZH_ORIGINAL_LOCALAPPDATA = [string]$config.originalLocalAppData
+    $script:LanguageCode = $maintenanceLanguage
+    $script:PatchMode = $maintenanceMode
+    $script:IsMaintenanceRun = $true
+
+    $paths = Get-ClaudeResourcesPath
+    $resourcesPath = [string]$paths["Resources"]
+    $markerPath = Get-PatchMarkerPath $resourcesPath
+    $existingMarker = $null
+    if (Test-Path -LiteralPath $markerPath -PathType Leaf) {
+        $existingMarker = Read-PatchMarker $resourcesPath
+        if ($existingMarker -and (Test-WindowsPatchCurrent $existingMarker $paths $maintenanceLanguage $maintenanceMode)) {
+            # Fully healthy install: drop any stale resume state left behind by a previous crash.
+            Clear-WindowsPendingRestore $resourcesPath
+            Write-Host "  当前 Claude 版本的汉化状态已完整验证，维护任务无需操作。" -ForegroundColor Green
+            return
+        }
+    }
+    if (-not (Test-WindowsMaintenanceReady $paths)) {
+        return
+    }
+
+    # Resume an interrupted exact restore before any fingerprint-based decisions.
+    # A half-restored tree intentionally fails patched fingerprint checks and must
+    # not be treated as an official upstream update.
+    $pendingRestore = Read-WindowsPendingRestore $resourcesPath
+    if ($pendingRestore) {
+        if (Test-WindowsPendingRestoreMatchesCurrentApp $pendingRestore $paths) {
+            Write-Host "  检测到未完成的精确备份恢复；继续同一份备份，不会误判为官方新版。" -ForegroundColor DarkYellow
+            [void](Invoke-WindowsPendingRestore $pendingRestore $paths)
+            $existingMarker = $null
+        }
+        else {
+            Write-Host "  待续作恢复状态与当前 Claude build 不匹配（可能官方已更新）；丢弃旧恢复状态与旧备份。" -ForegroundColor DarkYellow
+            Clear-WindowsPendingRestore $resourcesPath
+            Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Get-BackupRoot $resourcesPath) -Recurse -Force -ErrorAction SilentlyContinue
+            $existingMarker = $null
+        }
+    }
+
+    if (Test-Path -LiteralPath $markerPath -PathType Leaf) {
+        if (-not $existingMarker) {
+            $existingMarker = Read-PatchMarker $resourcesPath
+        }
+        $exactPatchedBuild = $existingMarker -and
+            (Test-PatchMarkerMatchesIdentity $existingMarker $paths) -and
+            (Test-PatchMarkerMatchesFingerprint $existingMarker $paths)
+        if ($exactPatchedBuild) {
+            Write-Host "  当前 build 的部分汉化资源缺失；先从精确 marker 备份恢复官方基线，再完整重装。" -ForegroundColor DarkYellow
+            $restored = Uninstall-WindowsLanguagePack -ForReinstall
+            if (-not $restored) {
+                throw "无法从当前 build 的精确 marker 备份恢复，已停止自动修复。"
+            }
+        }
+        else {
+            Write-Host "  marker 的 build 或补丁指纹已变化；不会恢复旧文件，将以当前官方资源为新基线。" -ForegroundColor DarkYellow
+            Clear-WindowsPendingRestore $resourcesPath
+            Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Get-BackupRoot $resourcesPath) -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    $failurePath = Join-Path $root "failure.json"
+    $fingerprint = Get-WindowsMaintenanceFingerprint $paths
+    $fingerprintJson = $fingerprint | ConvertTo-Json -Compress -Depth 20
+    if (Test-Path -LiteralPath $failurePath -PathType Leaf) {
+        try {
+            $previousFailure = Get-Content -LiteralPath $failurePath -Raw -Encoding UTF8 | ConvertFrom-Json
+            $previousFingerprintJson = $previousFailure.fingerprint | ConvertTo-Json -Compress -Depth 20
+            $samePatchVersion = [string]$previousFailure.patchVersion -eq (Get-PatchReleaseVersion)
+            if ($samePatchVersion -and $previousFingerprintJson -eq $fingerprintJson) {
+                $failedAt = [DateTimeOffset]::Parse([string]$previousFailure.failedAt).ToUniversalTime()
+                $retryAt = $failedAt.AddSeconds($WindowsMaintenanceFailureRetrySeconds)
+                if ([DateTimeOffset]::UtcNow -lt $retryAt) {
+                    Write-Host "  此 Claude build 最近已安全回滚；六小时退避期内不重复尝试。" -ForegroundColor DarkYellow
+                    return
+                }
+            }
+        }
+        catch {
+            Remove-Item -LiteralPath $failurePath -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    try {
+        $requestedMode = $script:PatchMode
+        $maintenanceInstalled = Install-WindowsLanguagePackWithFallback
+        if (-not $maintenanceInstalled) {
+            return
+        }
+        if ($requestedMode -eq "official" -and $script:PatchMode -eq "safe") {
+            $config.patchMode = "safe"
+            Save-JsonNoBom $configPath $config 10
+            Write-Host "  后续自动维护已切换为基础模式。" -ForegroundColor DarkYellow
+        }
+        Remove-Item -LiteralPath $failurePath -Force -ErrorAction SilentlyContinue
+    }
+    catch {
+        $failedFingerprint = Get-WindowsMaintenanceFingerprint $paths
+        $failure = [ordered]@{
+            failedAt = [DateTimeOffset]::UtcNow.ToString("o")
+            patchVersion = Get-PatchReleaseVersion
+            message = $_.Exception.Message
+            fingerprint = $failedFingerprint
+        }
+        Save-JsonNoBom $failurePath $failure 20
+        throw
+    }
+}
+
+function Invoke-WindowsMaintenance {
+    $mutex = New-Object System.Threading.Mutex($false, "Global\ClaudeDesktopZhCn-Installer")
+    $mutexAcquired = $false
+    try {
+        try {
+            if (-not $mutex.WaitOne(0)) {
+                Write-Host "  另一个安装或维护进程正在运行，本次维护延后。" -ForegroundColor DarkYellow
+                return
+            }
+            $mutexAcquired = $true
+        }
+        catch [System.Threading.AbandonedMutexException] {
+            $mutexAcquired = $true
+        }
+        Invoke-WindowsMaintenanceLocked
+    }
+    finally {
+        if ($mutexAcquired) {
+            $mutex.ReleaseMutex()
+        }
+        $mutex.Dispose()
+    }
+}
+
+function Remove-WindowsMaintenancePayload {
+    try {
+        $root = Get-WindowsMaintenanceRoot
+        if (-not (Test-Path -LiteralPath $root)) {
+            return
+        }
+        if (Test-PathIsReparsePoint $root) {
+            Write-Host "  [警告] 维护目录是 reparse point，拒绝自动删除: $root" -ForegroundColor DarkYellow
+            return
+        }
+        Remove-Item -LiteralPath $root -Recurse -Force
+        Write-Host "  removed maintenance payload: $root" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "  [警告] 无法删除维护 payload: $($_.Exception.Message)" -ForegroundColor DarkYellow
     }
 }
 
@@ -3189,31 +4550,6 @@ function Unsync-CCSwitchSkills {
     }
 }
 
-function Remove-LanguageFiles {
-    param([string]$ResourcesPath)
-
-    $targets = @(
-        (Join-Path $ResourcesPath "ion-dist\i18n\zh-CN.json"),
-        (Join-Path $ResourcesPath "zh-CN.json"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\statsig\zh-CN.json"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\zh-TW.json"),
-        (Join-Path $ResourcesPath "zh-TW.json"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\statsig\zh-TW.json"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\zh-HK.json"),
-        (Join-Path $ResourcesPath "zh-HK.json"),
-        (Join-Path $ResourcesPath "ion-dist\i18n\statsig\zh-HK.json")
-    )
-
-    foreach ($target in $targets) {
-        Remove-Item $target -Force -ErrorAction SilentlyContinue
-        if (-not (Test-Path $target)) {
-            Write-Host "  removed: $target" -ForegroundColor Green
-        } else {
-            Write-Host "  [警告] 未能删除: $target" -ForegroundColor DarkYellow
-        }
-    }
-}
-
 function Test-ClaudeDesktopProcessPath {
     param([string]$Path)
 
@@ -3364,16 +4700,20 @@ function Restart-Claude {
 
 function Install-WindowsLanguagePack {
     $label = Get-LanguageLabel $LanguageCode
+    $script:LastInstallRollbackSucceeded = $true
 
     # 单实例互斥锁：防止多个安装进程并发写入 app.asar
     $mutex = New-Object System.Threading.Mutex($false, "Global\ClaudeDesktopZhCn-Installer")
+    $mutexAcquired = $false
+    $resourcesPath = $null
     try {
         if (-not $mutex.WaitOne(0)) {
-            Write-Host "  [错误] 另一个安装进程正在运行，请等待其完成后再试。" -ForegroundColor Red
-            return
+            throw "另一个安装进程正在运行，请等待其完成后再试。"
         }
+        $mutexAcquired = $true
     } catch [System.Threading.AbandonedMutexException] {
         # 上一个进程异常退出，锁已释放，继续执行
+        $mutexAcquired = $true
     }
 
     Write-Host "=== Claude Desktop Windows $label 补丁 ===" -ForegroundColor Cyan
@@ -3389,9 +4729,6 @@ function Install-WindowsLanguagePack {
         Write-Step "[2/8] 检查语言资源"
         $pack = Get-LanguageResources $LanguageCode
 
-        Write-Step "关闭 Claude Desktop"
-        Stop-ClaudeProcesses
-
         Write-Step "[3/8] 查找 Claude Desktop"
         $paths = Get-ClaudeResourcesPath
         $claudePath = $paths["App"]
@@ -3400,9 +4737,23 @@ function Install-WindowsLanguagePack {
         Write-Host "  app: $claudePath" -ForegroundColor Green
         Write-Host "  resources: $resourcesPath" -ForegroundColor Green
 
+        if ($script:IsMaintenanceRun) {
+            $staleMarkerPath = Get-PatchMarkerPath $resourcesPath
+            if (Test-Path -LiteralPath $staleMarkerPath -PathType Leaf) {
+                throw "维护预检后仍存在 patch marker，拒绝覆盖其备份状态。"
+            }
+        }
+        else {
+            Write-Step "关闭 Claude Desktop"
+            Stop-ClaudeProcesses
+        }
+
         Write-Step "[4/8] 准备写入权限"
         Enable-WriteAccess $resourcesPath
-        Remove-LegacyAppxForkArtifacts
+        if (-not $script:IsMaintenanceRun) {
+            Remove-LegacyAppxForkArtifacts
+        }
+        Start-InstallTransaction $resourcesPath
 
         Write-Step "[5/8] 写入 $label 资源"
         Install-LanguageFiles $resourcesPath $pack $LanguageCode
@@ -3427,22 +4778,40 @@ function Install-WindowsLanguagePack {
             Write-Host "  skipping Claude.exe asar integrity sync due to patch mode: $PatchMode" -ForegroundColor DarkYellow
         }
 
-        Write-Step "[8/8] 写入用户语言配置"
-        Set-ClaudeLocale $LanguageCode
+        Write-Step "[8/8] 验证并记录当前版本补丁状态"
+        Write-PatchMarker $resourcesPath $paths $LanguageCode $PatchMode
+        Complete-InstallTransaction
 
-        Write-Step "重启 Claude Desktop"
-        Restart-Claude $claudePath
+        try {
+            Set-ClaudeLocale $LanguageCode
+        }
+        catch {
+            Write-Host "  [警告] 汉化已安装，但无法自动写入用户语言配置: $($_.Exception.Message)" -ForegroundColor DarkYellow
+        }
 
-        Write-Step "启动 CoworkVMService"
-        Start-CoworkVMService
+        if (-not $script:IsMaintenanceRun) {
+            try {
+                Write-Step "重启 Claude Desktop"
+                Restart-Claude $claudePath
+
+                Write-Step "启动 CoworkVMService"
+                Start-CoworkVMService
+            }
+            catch {
+                Write-Host "  [警告] 汉化已提交，但 Claude/Cowork 自动重启失败，请手动启动: $($_.Exception.Message)" -ForegroundColor DarkYellow
+            }
+        }
 
         Write-Host ""
         Write-Host "安装完成。如果界面未立即切换，请在 Language 中选择 $label。" -ForegroundColor Green
+        return $true
     }
     catch {
         Write-Host ""
-        Write-Host "安装过程中出现错误，Claude Desktop 可能处于不完整状态。" -ForegroundColor Red
-        Write-Host "  建议运行卸载命令恢复原始状态：install-windows.bat → 选择卸载。" -ForegroundColor DarkYellow
+        if ($resourcesPath -and $script:InstallTransactionActive) {
+            [void](Rollback-InstallTransaction $resourcesPath)
+        }
+        Write-Host "安装过程中出现错误，本次已备份的文件已尝试自动回滚。" -ForegroundColor Red
         Write-Host "  详细日志: $script:InstallLogPath" -ForegroundColor DarkGray
         if ($script:DetectedMultipleClaudeInstalls) {
             Write-MultipleClaudeFailureHint
@@ -3450,44 +4819,134 @@ function Install-WindowsLanguagePack {
         throw
     }
     finally {
-        $mutex.ReleaseMutex()
+        if ($mutexAcquired) {
+            $mutex.ReleaseMutex()
+        }
         $mutex.Dispose()
     }
 }
 
 function Uninstall-WindowsLanguagePack {
+    param([switch]$ForReinstall)
+
     Write-Host "=== Claude Desktop Windows 中文补丁卸载 ===" -ForegroundColor Cyan
 
-    $oldSkipAsarPatch = $SkipAsarPatch
-    $SkipAsarPatch = $true
+    # Nested calls from maintenance already hold the same named mutex; skip re-acquire.
+    $ownsMutex = -not $script:IsMaintenanceRun
+    $mutex = $null
+    $mutexAcquired = $false
+    if ($ownsMutex) {
+        $mutex = New-Object System.Threading.Mutex($false, "Global\ClaudeDesktopZhCn-Installer")
+        try {
+            if (-not $mutex.WaitOne(0)) {
+                throw "另一个安装或维护进程正在运行，请等待其完成后再试。"
+            }
+            $mutexAcquired = $true
+        }
+        catch [System.Threading.AbandonedMutexException] {
+            $mutexAcquired = $true
+        }
+    }
+
     try {
-        $paths = Get-ClaudeResourcesPath
+        $oldSkipAsarPatch = $SkipAsarPatch
+        $SkipAsarPatch = $true
+        try {
+            $paths = Get-ClaudeResourcesPath
+        }
+        finally {
+            $SkipAsarPatch = $oldSkipAsarPatch
+        }
+        $resourcesPath = $paths["Resources"]
+        $markerPath = Get-PatchMarkerPath $resourcesPath
+
+        # Resume an interrupted exact restore first (identity-only; fingerprint may already be half-restored).
+        $pendingRestore = Read-WindowsPendingRestore $resourcesPath
+        if ($pendingRestore) {
+            if (Test-WindowsPendingRestoreMatchesCurrentApp $pendingRestore $paths) {
+                Write-Host "  检测到未完成的精确备份恢复，继续同一份备份..." -ForegroundColor DarkYellow
+                Write-Step "关闭 Claude Desktop"
+                Stop-ClaudeProcesses
+                if (-not $script:IsMaintenanceRun) {
+                    Remove-LegacyAppxForkArtifacts
+                }
+                [void](Invoke-WindowsPendingRestore $pendingRestore $paths)
+                Write-Host ""
+                Write-Host "卸载完成。请重启 Claude Desktop 使更改生效。" -ForegroundColor Green
+                return $true
+            }
+            Write-Host "  待续作恢复状态与当前 build 不匹配；丢弃过期状态。" -ForegroundColor DarkYellow
+            Clear-WindowsPendingRestore $resourcesPath
+        }
+
+        if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+            Write-Host "  当前 Claude 版本没有 patch marker；不会恢复任何旧备份。" -ForegroundColor DarkYellow
+            if (-not $ForReinstall) {
+                Set-ClaudeLocale "en-US"
+            }
+            return $false
+        }
+
+        $marker = Read-PatchMarker $resourcesPath
+        if (-not $marker) {
+            Write-Host "  marker 无效；为避免跨版本恢复，仅清理无效元数据。" -ForegroundColor DarkYellow
+            Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+            Clear-WindowsPendingRestore $resourcesPath
+            $invalidBackupRoot = Get-BackupRoot $resourcesPath
+            Remove-Item -LiteralPath $invalidBackupRoot -Recurse -Force -ErrorAction SilentlyContinue
+            if (-not $ForReinstall) {
+                Set-ClaudeLocale "en-US"
+            }
+            return $false
+        }
+
+        if (-not (Test-PatchMarkerMatchesIdentity $marker $paths) -or -not (Test-PatchMarkerMatchesFingerprint $marker $paths)) {
+            Write-Host "  marker 对应的 build 或已打补丁文件指纹已变化；为避免降级，不会恢复其旧备份。" -ForegroundColor DarkYellow
+            $staleBackup = Resolve-MarkerBackupSetPath $resourcesPath $marker
+            Remove-Item -LiteralPath $markerPath -Force -ErrorAction SilentlyContinue
+            Clear-WindowsPendingRestore $resourcesPath
+            Remove-BackupSetAfterRestore $resourcesPath $staleBackup
+            if (-not $ForReinstall) {
+                Set-ClaudeLocale "en-US"
+            }
+            return $false
+        }
+
+        Write-Step "关闭 Claude Desktop"
+        Stop-ClaudeProcesses
+        if (-not $script:IsMaintenanceRun) {
+            Remove-LegacyAppxForkArtifacts
+        }
+
+        # Persist resume state before the first file write so a crash mid-restore is recoverable.
+        Write-WindowsPendingRestore $resourcesPath $marker $paths
+        $backupSetPath = Resolve-MarkerBackupSetPath $resourcesPath $marker
+        Write-Step "[1/3] 恢复本版本备份文件"
+        [void](Restore-BackupSet $resourcesPath $backupSetPath)
+
+        Write-Step "[2/3] 删除仅由本次补丁创建的资源"
+        Remove-CreatedResourceFiles $resourcesPath @($marker.createdFiles)
+
+        Write-Step "[3/3] 恢复用户语言配置"
+        Set-ClaudeLocale "en-US"
+
+        Remove-Item -LiteralPath $markerPath -Force -ErrorAction Stop
+        Remove-BackupSetAfterRestore $resourcesPath $backupSetPath
+        Clear-WindowsPendingRestore $resourcesPath
+        $script:CurrentBackupSetPath = $null
+
+        Write-Host ""
+        Write-Host "卸载完成。请重启 Claude Desktop 使更改生效。" -ForegroundColor Green
+        return $true
     }
     finally {
-        $SkipAsarPatch = $oldSkipAsarPatch
+        if ($mutexAcquired -and $mutex) {
+            $mutex.ReleaseMutex()
+        }
+        if ($mutex) {
+            $mutex.Dispose()
+        }
     }
-    $claudePath = $paths["App"]
-    $resourcesPath = $paths["Resources"]
-
-    Write-Step "关闭 Claude Desktop"
-    Stop-ClaudeProcesses
-    Remove-LegacyAppxForkArtifacts
-
-    Write-Step "[1/4] 恢复前端 bundle 和 app.asar"
-    Restore-LatestBackup $resourcesPath
-    Sync-ClaudeExeAsarIntegrity $resourcesPath
-
-    Write-Step "[2/4] 删除中文资源"
-    Remove-LanguageFiles $resourcesPath
-
-    Write-Step "[3/4] 移除 zh-CN 语言注册"
-    Unregister-Language $resourcesPath
-
-    Write-Step "[4/4] 恢复用户语言配置"
-    Set-ClaudeLocale "en-US"
-
-    Write-Host ""
-    Write-Host "卸载完成。请重启 Claude Desktop 使更改生效。" -ForegroundColor Green
 }
 
 function Invoke-PreInstallCleanup {
@@ -3508,19 +4967,46 @@ function Invoke-PreInstallCleanup {
     }
 
     $resourcesPath = $paths["Resources"]
-    $backupRoot = Get-BackupRoot $resourcesPath
-    $backup = $null
-    if (Test-Path $backupRoot) {
-        $backup = Get-ChildItem $backupRoot -Directory -ErrorAction SilentlyContinue |
-            Sort-Object Name |
-            Select-Object -First 1
-    }
-    if (-not $backup) {
-        Write-Host "  未找到旧中文补丁备份，跳过预卸载。" -ForegroundColor DarkYellow
+    $markerPath = Get-PatchMarkerPath $resourcesPath
+    if (-not (Test-Path -LiteralPath $markerPath -PathType Leaf)) {
+        Write-Host "  当前版本没有 patch marker；不会恢复任何旧备份。" -ForegroundColor DarkYellow
         return
     }
 
-    Uninstall-WindowsLanguagePack
+    [void](Uninstall-WindowsLanguagePack -ForReinstall)
+}
+
+function Install-WindowsLanguagePackWithFallback {
+    try {
+        return Install-WindowsLanguagePack
+    }
+    catch {
+        $fullModeError = $_.Exception.Message
+        if ($script:PatchMode -ne "official") {
+            throw
+        }
+        if (-not $script:LastInstallRollbackSucceeded) {
+            throw "完整模式失败，且本次文件回滚未能完整确认。为保护唯一备份，已停止安装，不会继续基础模式。原错误: $fullModeError"
+        }
+
+        Write-Host ""
+        Write-Host "  [兼容回退] 完整 app.asar 增强与此 Claude build 不兼容，改用基础汉化模式重试。" -ForegroundColor Yellow
+        Write-Host "  [兼容详情] $fullModeError" -ForegroundColor DarkYellow
+        $script:PatchMode = "safe"
+        try {
+            $result = Install-WindowsLanguagePack
+            Write-Host "  [兼容回退] 基础汉化安装成功；app.asar 与 Claude.exe 未修改。" -ForegroundColor Green
+            return $result
+        }
+        catch {
+            throw "完整模式和基础模式均未通过兼容检查。完整模式: $fullModeError；基础模式: $($_.Exception.Message)"
+        }
+    }
+}
+
+if ($LibraryMode) {
+    Stop-InstallLog
+    return
 }
 
 if ($Interactive) {
@@ -3539,10 +5025,40 @@ $LanguageCode = $Language
 try {
     switch ($Action) {
         "install" {
-            Invoke-PreInstallCleanup
-            Install-WindowsLanguagePack
+            $oldMaintenanceEnabled = Test-WindowsMaintenanceTaskEnabled
+            Disable-WindowsMaintenanceTask
+            try {
+                Invoke-PreInstallCleanup
+                $installed = Install-WindowsLanguagePackWithFallback
+            }
+            catch {
+                if ($oldMaintenanceEnabled) {
+                    Enable-WindowsMaintenanceTask
+                }
+                throw
+            }
+            if ($installed) {
+                try {
+                    Install-WindowsMaintenanceTask $LanguageCode $PatchMode
+                }
+                catch {
+                    Remove-WindowsMaintenanceTask
+                    Remove-WindowsMaintenancePayload
+                    Write-Host "  [警告] 汉化已安装，但自动维护任务安装失败: $($_.Exception.Message)" -ForegroundColor DarkYellow
+                }
+            }
         }
-        "uninstall" { Uninstall-WindowsLanguagePack }
+        "maintain" { Invoke-WindowsMaintenance }
+        "uninstall" {
+            Disable-WindowsMaintenanceTask
+            try {
+                [void](Uninstall-WindowsLanguagePack)
+            }
+            finally {
+                Remove-WindowsMaintenanceTask
+                $script:RemoveMaintenancePayloadAfterLog = $true
+            }
+        }
         "disable-updates" { Set-ClaudeAutoUpdates $false }
         "enable-updates" { Set-ClaudeAutoUpdates $true }
         "sync-skills" { Sync-CCSwitchSkills }
@@ -3550,6 +5066,9 @@ try {
     }
 
     Stop-InstallLog
+    if ($script:RemoveMaintenancePayloadAfterLog) {
+        Remove-WindowsMaintenancePayload
+    }
     exit 0
 }
 catch {
@@ -3559,6 +5078,9 @@ catch {
         Write-Host "[错误] 详细日志已写入: $script:InstallLogPath" -ForegroundColor Red
     }
     Stop-InstallLog
+    if ($script:RemoveMaintenancePayloadAfterLog) {
+        Remove-WindowsMaintenancePayload
+    }
     if ($Interactive) {
         [void](Read-Host "安装未完成，按 Enter 退出")
     }

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -115,14 +115,31 @@ function Test-GitHubReleaseUpdate {
             return
         }
 
-        $latestRelease = Invoke-RestMethod `
-            -Uri "https://api.github.com/repos/$repo/releases/latest" `
-            -Headers @{ Accept = "application/vnd.github+json"; "User-Agent" = "claude-desktop-zh-cn-update-check" } `
-            -TimeoutSec 3 `
-            -ErrorAction Stop
-        $latest = [string]$latestRelease.tag_name
+        $latest = $null
+        try {
+            $latestRelease = Invoke-RestMethod `
+                -Uri "https://api.github.com/repos/$repo/releases/latest" `
+                -Headers @{ Accept = "application/vnd.github+json"; "User-Agent" = "claude-desktop-zh-cn-update-check" } `
+                -TimeoutSec 3 `
+                -ErrorAction Stop
+            $latest = [string]$latestRelease.tag_name
+        }
+        catch {
+            # 国内网络经常无法访问 api.github.com；回退到 jsDelivr 的包 API，
+            # 它镜像 GitHub tag 且在国内可达。
+            $mirror = Invoke-RestMethod `
+                -Uri "https://data.jsdelivr.com/v1/package/gh/$repo" `
+                -Headers @{ "User-Agent" = "claude-desktop-zh-cn-update-check" } `
+                -TimeoutSec 3 `
+                -ErrorAction Stop
+            $versions = @($mirror.versions)
+            if ($versions.Count -gt 0) {
+                $latest = [string]$versions[0]
+            }
+        }
         if ($latest -and ((Compare-ReleaseVersion $latest $current) -gt 0)) {
-            Write-Host "检测到 GitHub Releases 已发布新版 $latest，当前脚本包为 $current。建议及时更新。本次操作会继续执行。" -ForegroundColor Yellow
+            Write-Host "检测到项目已发布新版 $latest，当前脚本包为 $current。建议及时更新。本次操作会继续执行。" -ForegroundColor Yellow
+            Write-Host "国内网络下载较慢时，可参考 README 的「国内用户下载」章节。" -ForegroundColor Yellow
             Write-Host ""
         }
     }

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -4986,7 +4986,7 @@ function Install-WindowsLanguagePackWithFallback {
             throw
         }
         if (-not $script:LastInstallRollbackSucceeded) {
-            throw "完整模式失败，且本次文件回滚未能完整确认。为保护唯一备份，已停止安装，不会继续基础模式。原错误: $fullModeError"
+            throw "[fullmode-halt] 完整模式失败，且本次文件回滚未能完整确认。为保护唯一备份，已停止安装，不会继续基础模式。原错误: $fullModeError"
         }
 
         Write-Host ""

--- a/scripts/macos_auto_repair.py
+++ b/scripts/macos_auto_repair.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Root-owned launchd controller that reapplies the bundled patch after an update."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import fcntl
+import json
+import os
+import pwd
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import patch_claude_zh_cn as patcher
+
+
+STATE_PATH = patcher.AUTO_REPAIR_ROOT / "state.json"
+FAILURE_RETRY_SECONDS = 6 * 60 * 60
+
+
+def log(message: str) -> None:
+    stamp = dt.datetime.now().astimezone().isoformat(timespec="seconds")
+    print(f"[{stamp}] {message}", flush=True)
+
+
+def load_object(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            value = json.load(f)
+    except FileNotFoundError:
+        return {}
+    if not isinstance(value, dict):
+        raise SystemExit(f"Expected a JSON object: {path}")
+    return value
+
+
+def save_object(path: Path, value: dict[str, Any]) -> None:
+    patcher.save_json(path, value)
+    os.chmod(path, 0o600)
+    os.chown(path, 0, 0)
+
+
+def validate_config(value: dict[str, Any], path: Path) -> dict[str, Any]:
+    if value.get("schema") != 1:
+        raise SystemExit(f"Unsupported auto-repair config schema in {path}")
+    if value.get("language") not in {"zh-CN", "zh-TW", "zh-HK"}:
+        raise SystemExit(f"Invalid auto-repair language in {path}")
+    if value.get("mode") not in {"full", "safe"}:
+        raise SystemExit(f"Invalid auto-repair mode in {path}")
+
+    app = Path(str(value.get("app", "")))
+    user_home = Path(str(value.get("userHome", "")))
+    if not app.is_absolute() or not user_home.is_absolute():
+        raise SystemExit(f"Auto-repair paths must be absolute in {path}")
+    if not patcher.path_is_within(app.resolve(), Path("/Applications").resolve()):
+        raise SystemExit(f"Refusing to auto-repair an app outside /Applications: {app}")
+    return value
+
+
+def claude_is_running() -> bool:
+    result = subprocess.run(
+        ["/usr/bin/pgrep", "-x", "Claude"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def launch_for_user(app: Path, user_home: Path) -> None:
+    try:
+        uid = user_home.stat().st_uid
+        user_name = pwd.getpwuid(uid).pw_name
+    except Exception as exc:
+        log(f"Cannot determine user for relaunch: {exc}")
+        return
+    env = os.environ.copy()
+    env["HOME"] = str(user_home)
+    env["USER"] = user_name
+    env["LOGNAME"] = user_name
+    subprocess.run(
+        ["/bin/launchctl", "asuser", str(uid), "/usr/bin/open", "-a", str(app)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+def app_is_settled(app: Path) -> bool:
+    watched = [app / "Contents/Info.plist", app / patcher.APP_ASAR_REL]
+    try:
+        newest = max(path.stat().st_mtime for path in watched)
+    except FileNotFoundError:
+        return False
+    return time.time() - newest >= patcher.AUTO_REPAIR_SETTLE_SECONDS
+
+
+def failure_is_backed_off(state: dict[str, Any], fingerprint: dict[str, Any], release: str) -> bool:
+    if state.get("failedFingerprint") != fingerprint or state.get("patchRelease") != release:
+        return False
+    try:
+        failed_at = float(state.get("failedAt", 0))
+    except (TypeError, ValueError):
+        return False
+    return time.time() - failed_at < FAILURE_RETRY_SECONDS
+
+
+def run_once(config_path: Path) -> int:
+    config = validate_config(load_object(config_path), config_path)
+    app = Path(config["app"])
+    user_home = Path(config["userHome"])
+    language = str(config["language"])
+    mode = str(config["mode"])
+    release = patcher.get_patch_release()
+
+    if not app.exists():
+        log(f"Claude.app is temporarily absent; waiting for the updater: {app}")
+        return 0
+    if patcher.patch_is_current(app, language, mode):
+        if STATE_PATH.exists():
+            STATE_PATH.unlink()
+        return 0
+    try:
+        fingerprint = patcher.get_app_fingerprint(app)
+    except (Exception, SystemExit) as exc:
+        log(f"Claude.app is not readable yet; waiting for the official updater: {exc}")
+        return 0
+    state = load_object(STATE_PATH)
+    if failure_is_backed_off(state, fingerprint, release):
+        log("The same Claude build already failed compatibility checks; retry is backed off")
+        return 0
+    if state.get("observedFingerprint") != fingerprint:
+        save_object(
+            STATE_PATH,
+            {
+                "observedFingerprint": fingerprint,
+                "observedAt": time.time(),
+                "patchRelease": release,
+            },
+        )
+        log("Observed a new Claude build; waiting for one unchanged observation before repair")
+        return 0
+    try:
+        observed_at = float(state.get("observedAt", 0))
+    except (TypeError, ValueError):
+        observed_at = 0
+    if time.time() - observed_at < patcher.AUTO_REPAIR_SETTLE_SECONDS or not app_is_settled(app):
+        log("Claude.app is not settled yet; waiting for the official updater to finish")
+        return 0
+
+    was_running = claude_is_running()
+    command = [
+        sys.executable,
+        str(Path(patcher.__file__).resolve()),
+        "--app",
+        str(app),
+        "--user-home",
+        str(user_home),
+        "--lang",
+        language,
+        "--maintenance-run",
+        "--no-auto-repair",
+    ]
+    if mode == "safe":
+        command.append("--skip-asar-patch")
+
+    log(
+        f"Detected an unpatched Claude update "
+        f"{fingerprint['identity'].get('version')} ({fingerprint['identity'].get('build')}); repairing"
+    )
+    result = subprocess.run(command, check=False)
+    if was_running:
+        launch_for_user(app, user_home)
+    if result.returncode == 0:
+        if STATE_PATH.exists():
+            STATE_PATH.unlink()
+        marker = patcher.read_patch_marker(app) or {}
+        repaired_mode = marker.get("mode")
+        if repaired_mode in {"full", "safe"} and repaired_mode != mode:
+            config["mode"] = repaired_mode
+            save_object(config_path, config)
+            log(f"Compatibility fallback changed the maintained patch mode to {repaired_mode}")
+        log("Automatic Chinese patch repair completed")
+        return 0
+
+    save_object(
+        STATE_PATH,
+        {
+            "observedFingerprint": fingerprint,
+            "observedAt": observed_at or time.time(),
+            "failedFingerprint": fingerprint,
+            "patchRelease": release,
+            "failedAt": time.time(),
+            "exitCode": result.returncode,
+        },
+    )
+    log(f"Automatic repair failed with exit code {result.returncode}; the official app was kept")
+    return result.returncode
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Maintain the Claude Desktop Chinese patch after updates")
+    parser.add_argument("--config", type=Path, required=True)
+    args = parser.parse_args()
+
+    patcher.AUTO_REPAIR_LOCK.parent.mkdir(parents=True, exist_ok=True)
+    with patcher.AUTO_REPAIR_LOCK.open("a+", encoding="utf-8") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            log("Another repair process is already running")
+            return 0
+        return run_once(args.config)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/macos_auto_repair.py
+++ b/scripts/macos_auto_repair.py
@@ -9,6 +9,7 @@ import fcntl
 import json
 import os
 import pwd
+import re
 import subprocess
 import sys
 import time
@@ -20,11 +21,30 @@ import patch_claude_zh_cn as patcher
 
 STATE_PATH = patcher.AUTO_REPAIR_ROOT / "state.json"
 FAILURE_RETRY_SECONDS = 6 * 60 * 60
+LOG_ROTATE_BYTES = 1024 * 1024
+CLAUDE_BUNDLE_ID = "com.anthropic.claudefordesktop"
+QUIT_WAIT_SECONDS = 20
 
 
 def log(message: str) -> None:
     stamp = dt.datetime.now().astimezone().isoformat(timespec="seconds")
     print(f"[{stamp}] {message}", flush=True)
+
+
+def rotate_log_if_needed() -> None:
+    """Keep the launchd-managed log bounded: rename to .old once it exceeds the cap.
+
+    launchd already holds the log open for this run, so output keeps flowing to
+    the rotated file; the next launch recreates a fresh auto-repair.log.
+    """
+    try:
+        log_path = patcher.AUTO_REPAIR_LOG
+        if log_path.stat().st_size >= LOG_ROTATE_BYTES:
+            log_path.replace(log_path.with_suffix(log_path.suffix + ".old"))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        log(f"Log rotation skipped: {exc}")
 
 
 def load_object(path: Path) -> dict[str, Any]:
@@ -61,14 +81,66 @@ def validate_config(value: dict[str, Any], path: Path) -> dict[str, Any]:
     return value
 
 
-def claude_is_running() -> bool:
+def claude_is_running(app: Path) -> bool:
+    # Match by bundle path prefix instead of the bare name "Claude" so an
+    # unrelated process that happens to share the name never triggers a relaunch.
+    # macOS pgrep cannot read the Electron main process's argv (it falls back to
+    # a truncated comm), so `pgrep -x Claude` misses it entirely; the app's
+    # helper children (renderer/GPU/crashpad) always run from inside the bundle
+    # with readable argv, so a path-prefix match reliably detects a running app.
+    # ^ anchors to argv[0]: only processes launched from inside the bundle
+    # match, not unrelated commands whose arguments mention the path.
+    bundle_prefix = "^" + re.escape(str(app.resolve() / "Contents") + "/")
     result = subprocess.run(
-        ["/usr/bin/pgrep", "-x", "Claude"],
+        ["/usr/bin/pgrep", "-f", bundle_prefix],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         check=False,
     )
     return result.returncode == 0
+
+
+def quit_claude_for_user(app: Path, user_home: Path) -> bool:
+    """Ask the user's GUI session to quit Claude; return True once it is gone.
+
+    This daemon runs in the system launchd domain, where a bare osascript has
+    no route to the user's Aqua session and the quit AppleEvent silently fails
+    (-600/-1743). Delivering it via `launchctl asuser` fixes the bootstrap
+    namespace; TCC may still deny Automation for root, so the caller must
+    treat a lingering process as "patch on disk, effective on next launch".
+    """
+    if not claude_is_running(app):
+        return True
+    try:
+        uid = user_home.stat().st_uid
+        user_name = pwd.getpwuid(uid).pw_name
+    except Exception as exc:
+        log(f"Cannot determine user for quitting Claude: {exc}")
+        return False
+    env = os.environ.copy()
+    env["HOME"] = str(user_home)
+    env["USER"] = user_name
+    env["LOGNAME"] = user_name
+    subprocess.run(
+        [
+            "/bin/launchctl",
+            "asuser",
+            str(uid),
+            "/usr/bin/osascript",
+            "-e",
+            f'tell application id "{CLAUDE_BUNDLE_ID}" to quit',
+        ],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    deadline = time.time() + QUIT_WAIT_SECONDS
+    while time.time() < deadline:
+        if not claude_is_running(app):
+            return True
+        time.sleep(1)
+    return not claude_is_running(app)
 
 
 def launch_for_user(app: Path, user_home: Path) -> None:
@@ -153,7 +225,17 @@ def run_once(config_path: Path) -> int:
         log("Claude.app is not settled yet; waiting for the official updater to finish")
         return 0
 
-    was_running = claude_is_running()
+    was_running = claude_is_running(app)
+    quit_ok = True
+    if was_running:
+        quit_ok = quit_claude_for_user(app, user_home)
+        if quit_ok:
+            log("Claude was quit from the user session for the repair")
+        else:
+            log(
+                "Claude is still running (Automation may be denied for root); "
+                "patching on disk anyway - the repair takes effect on the next launch"
+            )
     command = [
         sys.executable,
         str(Path(patcher.__file__).resolve()),
@@ -174,7 +256,9 @@ def run_once(config_path: Path) -> int:
         f"{fingerprint['identity'].get('version')} ({fingerprint['identity'].get('build')}); repairing"
     )
     result = subprocess.run(command, check=False)
-    if was_running:
+    if was_running and quit_ok:
+        # Only relaunch when the old instance actually quit; `open -a` against
+        # a still-running app would merely focus the unpatched instance.
         launch_for_user(app, user_home)
     if result.returncode == 0:
         if STATE_PATH.exists():
@@ -185,7 +269,13 @@ def run_once(config_path: Path) -> int:
             config["mode"] = repaired_mode
             save_object(config_path, config)
             log(f"Compatibility fallback changed the maintained patch mode to {repaired_mode}")
-        log("Automatic Chinese patch repair completed")
+        if was_running and not quit_ok:
+            log(
+                "Automatic Chinese patch repair completed on disk; "
+                "it takes effect after Claude restarts"
+            )
+        else:
+            log("Automatic Chinese patch repair completed")
         return 0
 
     save_object(
@@ -208,6 +298,7 @@ def main() -> int:
     parser.add_argument("--config", type=Path, required=True)
     args = parser.parse_args()
 
+    rotate_log_if_needed()
     patcher.AUTO_REPAIR_LOCK.parent.mkdir(parents=True, exist_ok=True)
     with patcher.AUTO_REPAIR_LOCK.open("a+", encoding="utf-8") as lock_file:
         try:

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -40,8 +40,18 @@ BACKUP_GLOB = "Claude.backup-before-zh-CN-*.app"
 
 APP_ASAR_REL = Path("Contents/Resources/app.asar")
 FRONTEND_I18N_REL = Path("Contents/Resources/ion-dist/i18n")
-FRONTEND_ASSETS_REL = Path("Contents/Resources/ion-dist/assets/v1")
 DESKTOP_RESOURCES_REL = Path("Contents/Resources")
+PATCH_MARKER_NAME = ".claude-zh-cn.json"
+PATCH_MARKER_SCHEMA = 1
+AUTO_REPAIR_LABEL = "cn.javaht.claude-desktop-zh-cn"
+AUTO_REPAIR_ROOT = Path("/Library/Application Support/ClaudeDesktopZhCN")
+AUTO_REPAIR_PAYLOAD = AUTO_REPAIR_ROOT / "payload"
+AUTO_REPAIR_CONFIG = AUTO_REPAIR_ROOT / "config.json"
+AUTO_REPAIR_LOG = AUTO_REPAIR_ROOT / "auto-repair.log"
+AUTO_REPAIR_LOCK = Path("/var/run/claude-desktop-zh-cn.lock")
+AUTO_REPAIR_PLIST = Path(f"/Library/LaunchDaemons/{AUTO_REPAIR_LABEL}.plist")
+AUTO_REPAIR_INTERVAL_SECONDS = 300
+AUTO_REPAIR_SETTLE_SECONDS = 90
 ASAR_PATCH_TARGET = ".vite/build/index.js"
 ASAR_INTEGRITY_BLOCK_SIZE = 4 * 1024 * 1024
 ONLINE_LOCALE_PRELOAD_TARGETS = [
@@ -86,10 +96,24 @@ def log(message: str) -> None:
 def elapsed_since(start: float) -> str:
     return f"{time.perf_counter() - start:.1f}s"
 
-LANG_LIST_RE = re.compile(
-    r'\["en-US","de-DE","fr-FR","ko-KR","ja-JP","es-419","es-ES","it-IT","hi-IN","pt-BR","id-ID"(?:(?:,"zh-CN")|(?:,"zh-TW")|(?:,"zh-HK"))*\]'
+KNOWN_FRONTEND_LOCALES = {
+    "en-US",
+    "de-DE",
+    "fr-FR",
+    "ko-KR",
+    "ja-JP",
+    "es-419",
+    "es-ES",
+    "it-IT",
+    "hi-IN",
+    "pt-BR",
+    "id-ID",
+}
+LOCALE_ARRAY_RE = re.compile(
+    r"\[(?:\s*[\"'][a-z]{2,3}(?:-[A-Za-z0-9]{2,8})?[\"']\s*,){2,}"
+    r"\s*[\"'][a-z]{2,3}(?:-[A-Za-z0-9]{2,8})?[\"']\s*\]"
 )
-BASE_LANGUAGE_LIST = '["en-US","de-DE","fr-FR","ko-KR","ja-JP","es-419","es-ES","it-IT","hi-IN","pt-BR","id-ID"'
+LOCALE_TOKEN_RE = re.compile(r"[\"'](?P<locale>[a-z]{2,3}(?:-[A-Za-z0-9]{2,8})?)[\"']")
 
 
 def get_language_config(lang_code: str) -> dict[str, Any]:
@@ -130,6 +154,117 @@ def save_json(path: Path, data: Any) -> None:
 def require_file(path: Path) -> None:
     if not path.exists():
         raise SystemExit(f"Missing required file: {path}")
+
+
+def get_patch_release() -> str:
+    try:
+        data = load_json(RESOURCES / "release.json")
+    except Exception:
+        return "unknown"
+    return str(data.get("release", "unknown")) if isinstance(data, dict) else "unknown"
+
+
+def get_app_identity(app: Path) -> dict[str, str]:
+    info_path = app / "Contents/Info.plist"
+    try:
+        with info_path.open("rb") as f:
+            info = plistlib.load(f)
+    except Exception as exc:
+        raise SystemExit(f"Cannot read Claude app identity from {info_path}: {exc}")
+    return {
+        "bundleId": str(info.get("CFBundleIdentifier", "")),
+        "version": str(info.get("CFBundleShortVersionString", "")),
+        "build": str(info.get("CFBundleVersion", "")),
+    }
+
+
+def get_app_fingerprint(app: Path) -> dict[str, Any]:
+    """Return a cheap build fingerprint that works even if ASAR internals change."""
+    asar_path = app / APP_ASAR_REL
+    require_file(asar_path)
+    digest = hashlib.sha256()
+    with asar_path.open("rb") as f:
+        digest.update(f.read(256 * 1024))
+    return {
+        "identity": get_app_identity(app),
+        "asarSize": asar_path.stat().st_size,
+        "asarPrefixSha256": digest.hexdigest(),
+    }
+
+
+def patch_marker_path(app: Path) -> Path:
+    return app / DESKTOP_RESOURCES_REL / PATCH_MARKER_NAME
+
+
+def read_patch_marker(app: Path) -> dict[str, Any] | None:
+    path = patch_marker_path(app)
+    if not path.is_file():
+        return None
+    try:
+        data = load_json(path)
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def write_patch_marker(
+    patched_app: Path,
+    source_app: Path,
+    lang_code: str,
+    patch_mode: str,
+) -> None:
+    marker = {
+        "schema": PATCH_MARKER_SCHEMA,
+        "patchRelease": get_patch_release(),
+        "language": lang_code,
+        "mode": patch_mode,
+        "appIdentity": get_app_identity(source_app),
+        "sourceFingerprint": get_app_fingerprint(source_app),
+        "patchedFingerprint": get_app_fingerprint(patched_app),
+        "patchedAt": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+    save_json(patch_marker_path(patched_app), marker)
+
+
+def marker_matches_installed_build(app: Path, marker: dict[str, Any]) -> bool:
+    """Reject markers preserved by an in-place upstream update."""
+    try:
+        return bool(
+            marker.get("schema") == PATCH_MARKER_SCHEMA
+            and marker.get("appIdentity") == get_app_identity(app)
+            and marker.get("patchedFingerprint") == get_app_fingerprint(app)
+        )
+    except (Exception, SystemExit):
+        return False
+
+
+def patch_is_current(app: Path, lang_code: str, patch_mode: str) -> bool:
+    marker = read_patch_marker(app)
+    if not marker:
+        return False
+    if (
+        not marker_matches_installed_build(app, marker)
+        or marker.get("patchRelease") != get_patch_release()
+        or marker.get("language") != lang_code
+        or marker.get("mode") != patch_mode
+    ):
+        return False
+    try:
+        locale_path = find_frontend_i18n_dir(app) / f"{lang_code}.json"
+        locale_data = load_json(locale_path)
+        whitelist_present = False
+        for bundle in find_frontend_js_files(app):
+            text = bundle.read_text(encoding="utf-8")
+            for match in LOCALE_ARRAY_RE.finditer(text):
+                locales = parse_locale_array(match.group(0))
+                if locales and lang_code in locales and locale_array_score(locales, text[max(0, match.start() - 160) : match.end() + 80]) >= 0:
+                    whitelist_present = True
+                    break
+            if whitelist_present:
+                break
+    except (Exception, SystemExit):
+        return False
+    return isinstance(locale_data, dict) and bool(locale_data) and whitelist_present
 
 
 def read_entitlements(path: Path) -> str:
@@ -174,37 +309,136 @@ def copy_app(src: Path, dst: Path) -> None:
     log(f"Copied app to temporary workspace in {elapsed_since(start)}")
 
 
-def patch_language_whitelist(app: Path, lang_code: str) -> Path:
-    assets_dir = app / FRONTEND_ASSETS_REL
-    candidates = sorted(assets_dir.glob("*.js"))
+def find_frontend_i18n_dir(app: Path) -> Path:
+    """Locate the primary frontend locale directory without assuming a versioned layout."""
+    preferred = app / FRONTEND_I18N_REL
+    if (preferred / "en-US.json").is_file():
+        return preferred
+
+    resources_dir = app / DESKTOP_RESOURCES_REL
+    candidates: list[tuple[int, Path]] = []
+    for en_path in resources_dir.rglob("en-US.json"):
+        relative_parts = {part.lower() for part in en_path.relative_to(resources_dir).parts}
+        if "statsig" in relative_parts or "node_modules" in relative_parts:
+            continue
+        try:
+            data = load_json(en_path)
+        except Exception:
+            continue
+        if not isinstance(data, dict):
+            continue
+        score = min(len(data), 20_000)
+        if en_path.parent.name.lower() in {"i18n", "locales"}:
+            score += 50_000
+        if "ion-dist" in relative_parts:
+            score += 25_000
+        candidates.append((score, en_path.parent))
+
     if not candidates:
-        raise SystemExit(f"Cannot find frontend JS bundle in {assets_dir}")
+        raise SystemExit(
+            f"Cannot locate Claude frontend en-US.json under {resources_dir}. "
+            "The frontend resource layout may have changed."
+        )
+    candidates.sort(key=lambda item: (-item[0], str(item[1])))
+    return candidates[0][1]
 
-    replacement = f'{BASE_LANGUAGE_LIST},"{lang_code}"]'
 
+def find_frontend_js_files(app: Path) -> list[Path]:
+    """Return frontend bundles across v1/v2/hashed asset directories."""
+    ion_dist = app / DESKTOP_RESOURCES_REL / "ion-dist"
+    search_roots = [ion_dist / "assets", ion_dist]
+    for root in search_roots:
+        if not root.is_dir():
+            continue
+        files = sorted(
+            path
+            for path in root.rglob("*.js")
+            if "node_modules" not in {part.lower() for part in path.parts}
+        )
+        if files:
+            return files
+    raise SystemExit(
+        f"Cannot find frontend JS bundles under {ion_dist}. "
+        "The frontend resource layout may have changed."
+    )
+
+
+def parse_locale_array(source: str) -> list[str] | None:
+    value = [match.group("locale") for match in LOCALE_TOKEN_RE.finditer(source)]
+    if len(value) < 3:
+        return None
+    return value
+
+
+def locale_array_score(locales: list[str], context: str) -> int:
+    known_count = len(KNOWN_FRONTEND_LOCALES.intersection(locales))
+    if "en-US" not in locales or known_count < 4:
+        return -1
+    score = known_count * 100 + len(locales)
+    if re.search(r"(?:locale|language|displayname)", context, re.IGNORECASE):
+        score += 1_000
+    return score
+
+
+def patch_language_whitelist(app: Path, lang_code: str) -> Path:
+    candidates = find_frontend_js_files(app)
+    matches: list[tuple[int, Path, int, int, list[str]]] = []
     for path in candidates:
         text = path.read_text(encoding="utf-8")
-        if replacement in text:
-            print(f"Language whitelist already contains {lang_code}: {path.name}")
-            return path
-        if LANG_LIST_RE.search(text):
-            patched = LANG_LIST_RE.sub(
-                replacement,
-                text,
-                count=1,
-            )
-            path.write_text(patched, encoding="utf-8")
-            print(f"Patched language whitelist: {path.name}")
-            return path
+        for match in LOCALE_ARRAY_RE.finditer(text):
+            locales = parse_locale_array(match.group(0))
+            if locales is None:
+                continue
+            context = text[max(0, match.start() - 160) : min(len(text), match.end() + 80)]
+            score = locale_array_score(locales, context)
+            if score >= 0:
+                matches.append((score, path, match.start(), match.end(), locales))
 
-    raise SystemExit("Could not patch language whitelist. Claude's bundle format may have changed.")
+    if not matches:
+        raise SystemExit(
+            "Could not locate Claude's language whitelist semantically. "
+            "Run the newest patch release or use --doctor to collect compatibility details."
+        )
+
+    best_score = max(item[0] for item in matches)
+    selected = [item for item in matches if item[0] == best_score]
+    by_path: dict[Path, list[tuple[int, int, list[str]]]] = {}
+    for _score, path, start, end, locales in selected:
+        by_path.setdefault(path, []).append((start, end, locales))
+
+    changed = 0
+    already = 0
+    for path, path_matches in by_path.items():
+        text = path.read_text(encoding="utf-8")
+        for start, end, locales in sorted(path_matches, reverse=True):
+            if lang_code in locales:
+                already += 1
+                continue
+            locales.append(lang_code)
+            replacement = json.dumps(locales, ensure_ascii=False, separators=(",", ":"))
+            text = text[:start] + replacement + text[end:]
+            changed += 1
+        path.write_text(text, encoding="utf-8")
+
+    primary = sorted(by_path)[0]
+    if changed:
+        print(
+            f"Patched language whitelist: {changed} candidate(s) across "
+            f"{len(by_path)} bundle(s); primary={primary.name}"
+        )
+    else:
+        print(f"Language whitelist already contains {lang_code}: {primary.name} ({already} candidate(s))")
+    return primary
 
 
-def patch_language_display_names(app: Path) -> None:
-    assets_dir = app / FRONTEND_ASSETS_REL
-    candidates = sorted(assets_dir.glob("index-*.js"))
-    if not candidates:
-        raise SystemExit(f"Cannot find frontend index bundle in {assets_dir}")
+def patch_language_display_names(app: Path, primary_bundle: Path | None = None) -> None:
+    if primary_bundle is not None:
+        candidates = [primary_bundle]
+    else:
+        all_bundles = find_frontend_js_files(app)
+        candidates = [path for path in all_bundles if path.name.startswith(("index-", "main-"))]
+        if not candidates:
+            candidates = all_bundles[:1]
 
     marker = "__claudeZhLabelPatch"
     patch = ';(()=>{const e=Intl.DisplayNames&&Intl.DisplayNames.prototype;if(!e||e.__claudeZhLabelPatch)return;const n=e.of;e.of=function(e){const t=String(e);return t==="zh-CN"?"简体中文":t==="zh-HK"?"繁体中文（中国香港）":t==="zh-TW"?"繁体中文（中国台湾）":n.call(this,e)},Object.defineProperty(e,"__claudeZhLabelPatch",{value:!0})})();'
@@ -273,13 +507,12 @@ def replace_frontend_hardcoded_text(text: str, source: str, target: str) -> tupl
 
 def patch_hardcoded_frontend_strings(app: Path, lang_code: str) -> None:
     start = time.perf_counter()
-    assets_dir = app / FRONTEND_ASSETS_REL
     replacement_items = sorted(
         load_frontend_hardcoded_replacements(lang_code),
         key=lambda item: len(item[0]),
         reverse=True,
     )
-    js_files = sorted(assets_dir.glob("*.js"))
+    js_files = find_frontend_js_files(app)
     patched_files = 0
     patched_strings = 0
 
@@ -479,9 +712,17 @@ def replace_asar_file_content(app: Path, file_path: str, patched_content: bytes)
     entry["size"] = len(patched_content)
     entry["integrity"] = calculate_file_integrity(patched_content)
     if delta:
-        for other in iter_asar_file_entries(header):
-            if other is not entry and int(other["offset"]) > target_offset:
-                set_asar_offset(other, int(other["offset"]) + delta)
+        ordered_entries = iter_asar_file_entries(header)
+        try:
+            target_index = next(index for index, other in enumerate(ordered_entries) if other is entry)
+        except StopIteration:
+            raise SystemExit(f"Internal patch error: lost ASAR entry for {file_path}.")
+        for index, other in enumerate(ordered_entries):
+            other_offset = int(other["offset"])
+            if index > target_index and other_offset >= target_offset:
+                # Empty files legitimately share an offset with the following file.
+                # Header order disambiguates them when the empty target grows.
+                set_asar_offset(other, other_offset + delta)
 
     updated_header_string = json.dumps(header, ensure_ascii=False, separators=(",", ":"))
     updated_header = encode_asar_header_dynamic(updated_header_string)
@@ -521,8 +762,18 @@ def patch_online_locale_preload(app: Path, lang_code: str) -> None:
     data = path.read_bytes()
     header_size, _header_string, header = read_asar_header(data, path)
 
+    available_files = {file_path: entry for file_path, entry in iter_asar_files(header)}
+    targets = [file_path for file_path in ONLINE_LOCALE_PRELOAD_TARGETS if file_path in available_files]
+    targets.extend(
+        file_path
+        for file_path in available_files
+        if file_path not in targets
+        and file_path.endswith(".js")
+        and Path(file_path).name in {"mainView.js", "mainWindow.js"}
+    )
+
     removed_count = 0
-    for file_path in ONLINE_LOCALE_PRELOAD_TARGETS:
+    for file_path in targets:
         entry = get_asar_file_entry(header, file_path)
         content_offset = 8 + header_size + int(entry["offset"])
         content_size = int(entry["size"])
@@ -541,7 +792,7 @@ def patch_online_locale_preload(app: Path, lang_code: str) -> None:
     if removed_count:
         print(f"Removed stale online claude.ai locale preload: {removed_count} files")
     else:
-        print("Online claude.ai locale preload not present")
+        print("Online claude.ai locale preload not present (missing legacy targets are compatible)")
 
 
 def is_online_dom_translation_entry(source: str, target: str) -> bool:
@@ -555,7 +806,7 @@ def is_online_dom_translation_entry(source: str, target: str) -> bool:
 
 def build_online_translation_map(app: Path, lang_code: str) -> dict[str, str]:
     config = get_language_config(lang_code)
-    en_path = app / FRONTEND_I18N_REL / "en-US.json"
+    en_path = find_frontend_i18n_dir(app) / "en-US.json"
     require_file(en_path)
     require_file(config["frontend_translation"])
 
@@ -813,7 +1064,7 @@ def find_main_process_asar_target(
     handler_matches: list[str] = []
 
     for file_path, entry in iter_asar_files(header):
-        if not (file_path.startswith(".vite/build/") and file_path.endswith(".js")):
+        if not file_path.endswith(".js") or int(entry.get("size", 0)) > 64 * 1024 * 1024:
             continue
         content = read_asar_entry_content(data, header_size, entry, file_path)
         if ONLINE_LOCALE_MAIN_MARKER.encode("utf-8") in content:
@@ -1763,8 +2014,9 @@ def patch_hardcoded_main_process_menu_labels(app: Path, lang_code: str) -> None:
 
 def merge_frontend_locale(app: Path, lang_code: str) -> tuple[int, int, int]:
     config = get_language_config(lang_code)
-    source = app / FRONTEND_I18N_REL / "en-US.json"
-    target = app / FRONTEND_I18N_REL / f"{lang_code}.json"
+    i18n_dir = find_frontend_i18n_dir(app)
+    source = i18n_dir / "en-US.json"
+    target = i18n_dir / f"{lang_code}.json"
     require_file(source)
     require_file(config["frontend_translation"])
 
@@ -1807,7 +2059,7 @@ def install_desktop_locale(app: Path, lang_code: str) -> None:
 
 def install_statsig_locale(app: Path, lang_code: str) -> None:
     config = get_language_config(lang_code)
-    statsig_dir = app / FRONTEND_I18N_REL / "statsig"
+    statsig_dir = find_frontend_i18n_dir(app) / "statsig"
     if not statsig_dir.exists():
         return
     target = statsig_dir / f"{lang_code}.json"
@@ -2303,10 +2555,145 @@ def unsync_cc_switch_skills(user_home: Path, skills_dir: Path, dry_run: bool = F
     return True
 
 
+def secure_root_owned_tree(path: Path) -> None:
+    for item in [path, *path.rglob("*")]:
+        os.chown(item, 0, 0)
+        if item.is_dir():
+            os.chmod(item, 0o755)
+        elif item.suffix in {".py", ".command"}:
+            os.chmod(item, 0o755)
+        else:
+            os.chmod(item, 0o644)
+
+
+def remove_macos_auto_repair(dry_run: bool = False) -> None:
+    if dry_run:
+        print(f"[dry-run] Would unload and remove auto-repair service: {AUTO_REPAIR_LABEL}")
+        return
+    run(["/bin/launchctl", "bootout", "system", str(AUTO_REPAIR_PLIST)], check=False)
+    if AUTO_REPAIR_PLIST.exists():
+        AUTO_REPAIR_PLIST.unlink()
+    if AUTO_REPAIR_ROOT.exists():
+        remove_path(AUTO_REPAIR_ROOT)
+    print("Removed macOS update auto-repair service")
+
+
+def install_macos_auto_repair(
+    app: Path,
+    user_home: Path,
+    lang_code: str,
+    patch_mode: str,
+    dry_run: bool = False,
+) -> None:
+    controller = ROOT / "scripts/macos_auto_repair.py"
+    require_file(controller)
+    if not path_is_within(app.resolve(), Path("/Applications").resolve()):
+        raise SystemExit("Automatic repair currently supports Claude.app installed under /Applications.")
+    if dry_run:
+        print(
+            f"[dry-run] Would install root-owned auto-repair service {AUTO_REPAIR_LABEL} "
+            f"for {lang_code}/{patch_mode}"
+        )
+        return
+    if os.geteuid() != 0:
+        raise SystemExit("Installing the macOS auto-repair service requires sudo/root.")
+
+    run(["/bin/launchctl", "bootout", "system", str(AUTO_REPAIR_PLIST)], check=False)
+    AUTO_REPAIR_ROOT.mkdir(parents=True, exist_ok=True)
+
+    staging_root = Path(tempfile.mkdtemp(prefix="claude-zh-auto-repair."))
+    staging_payload = staging_root / "payload"
+    try:
+        (staging_payload / "scripts").mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts/patch_claude_zh_cn.py", staging_payload / "scripts")
+        shutil.copy2(controller, staging_payload / "scripts")
+        shutil.copytree(RESOURCES, staging_payload / "resources")
+        if AUTO_REPAIR_PAYLOAD.exists():
+            remove_path(AUTO_REPAIR_PAYLOAD)
+        shutil.move(str(staging_payload), str(AUTO_REPAIR_PAYLOAD))
+    finally:
+        if staging_root.exists():
+            remove_path(staging_root)
+
+    config = {
+        "schema": 1,
+        "app": str(app.resolve()),
+        "userHome": str(user_home.resolve()),
+        "language": lang_code,
+        "mode": patch_mode,
+        "patchRelease": get_patch_release(),
+    }
+    save_json(AUTO_REPAIR_CONFIG, config)
+
+    plist = {
+        "Label": AUTO_REPAIR_LABEL,
+        "ProgramArguments": [
+            str(Path("/usr/bin/python3") if Path("/usr/bin/python3").exists() else Path(sys.executable).resolve()),
+            str(AUTO_REPAIR_PAYLOAD / "scripts/macos_auto_repair.py"),
+            "--config",
+            str(AUTO_REPAIR_CONFIG),
+        ],
+        "RunAtLoad": True,
+        "StartInterval": AUTO_REPAIR_INTERVAL_SECONDS,
+        "ThrottleInterval": 60,
+        "ProcessType": "Background",
+        "UserName": "root",
+        "GroupName": "wheel",
+        "StandardOutPath": str(AUTO_REPAIR_LOG),
+        "StandardErrorPath": str(AUTO_REPAIR_LOG),
+    }
+    AUTO_REPAIR_PLIST.parent.mkdir(parents=True, exist_ok=True)
+    with AUTO_REPAIR_PLIST.open("wb") as f:
+        plistlib.dump(plist, f, sort_keys=True)
+
+    secure_root_owned_tree(AUTO_REPAIR_ROOT)
+    os.chmod(AUTO_REPAIR_CONFIG, 0o600)
+    os.chown(AUTO_REPAIR_PLIST, 0, 0)
+    os.chmod(AUTO_REPAIR_PLIST, 0o644)
+
+    result = run(["/bin/launchctl", "bootstrap", "system", str(AUTO_REPAIR_PLIST)], check=False)
+    if result.returncode != 0:
+        raise SystemExit(
+            "Failed to load the macOS auto-repair service. launchctl output:\n" + result.stdout
+        )
+    print(
+        f"Installed update auto-repair service ({AUTO_REPAIR_INTERVAL_SECONDS // 60}-minute checks): "
+        f"{AUTO_REPAIR_LABEL}"
+    )
+
+
+def remove_backups(backups: list[Path], dry_run: bool, reason: str) -> None:
+    for backup in backups:
+        if dry_run:
+            print(f"[dry-run] Would remove {reason} backup: {backup}")
+        else:
+            print(f"Removing {reason} backup: {backup}")
+            remove_path(backup)
+
+
 def backup_and_replace(original: Path, patched: Path, dry_run: bool) -> Path:
     start = time.perf_counter()
     stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     backup = original.with_name(f"Claude.backup-before-zh-CN-{stamp}.app")
+    suffix = 0
+    while backup.exists():
+        suffix += 1
+        backup = original.with_name(f"Claude.backup-before-zh-CN-{stamp}-{suffix}.app")
+
+    stale_backups = find_app_backups(original)
+    existing_marker = read_patch_marker(original)
+    stale_marker = existing_marker is not None and not marker_matches_installed_build(original, existing_marker)
+    if stale_backups and (existing_marker is None or stale_marker):
+        # An official update has replaced the marked app. Its current files are
+        # the only valid baseline; an older backup must never downgrade it.
+        remove_backups(stale_backups, dry_run, "stale cross-version")
+    if stale_marker:
+        if dry_run:
+            print(f"[dry-run] Would remove stale patch marker: {patch_marker_path(original)}")
+        else:
+            print("Removing a patch marker preserved by an upstream in-place update")
+            patch_marker_path(original).unlink(missing_ok=True)
+
     if dry_run:
         print(f"[dry-run] Would move {original} -> {backup}")
         print(f"[dry-run] Would move {patched} -> {original}")
@@ -2314,8 +2701,14 @@ def backup_and_replace(original: Path, patched: Path, dry_run: bool) -> Path:
 
     log(f"Backing up current app: {backup}")
     shutil.move(str(original), str(backup))
-    log(f"Installing patched app: {original}")
-    shutil.move(str(patched), str(original))
+    try:
+        log(f"Installing patched app: {original}")
+        shutil.move(str(patched), str(original))
+    except Exception:
+        if not original.exists() and backup.exists():
+            log("Patched app commit failed; restoring the original app")
+            shutil.move(str(backup), str(original))
+        raise
     log(f"Replaced app in {elapsed_since(start)}")
     return backup
 
@@ -2331,20 +2724,71 @@ def find_app_backups(app: Path) -> list[Path]:
     return sorted(path for path in app.parent.glob(BACKUP_GLOB) if path.is_dir())
 
 
-def restore_oldest_backup(app: Path, dry_run: bool) -> Path:
+def has_legacy_patch_evidence(app: Path) -> bool:
+    if patch_marker_path(app).exists():
+        return True
+    resources_dir = app / DESKTOP_RESOURCES_REL
+    if any((resources_dir / f"{lang}.json").exists() for lang in ("zh-CN", "zh-TW", "zh-HK")):
+        try:
+            return any(
+                "__claudeZhLabelPatch" in path.read_text(encoding="utf-8")
+                for path in find_frontend_js_files(app)
+            )
+        except Exception:
+            return False
+    return False
+
+
+def select_compatible_backup(app: Path, backups: list[Path]) -> Path | None:
+    marker = read_patch_marker(app)
+    if marker is not None:
+        if marker.get("appIdentity") != get_app_identity(app):
+            return None
+        source_fingerprint = marker.get("sourceFingerprint")
+        for backup in backups:
+            try:
+                if get_app_fingerprint(backup) == source_fingerprint:
+                    return backup
+            except (Exception, SystemExit):
+                continue
+        return None
+
+    # One-time migration path for patches installed before markers existed.
+    if not has_legacy_patch_evidence(app):
+        return None
+    current_identity = get_app_identity(app)
+    for backup in backups:
+        try:
+            if get_app_identity(backup) == current_identity:
+                return backup
+        except (Exception, SystemExit):
+            continue
+    return None
+
+
+def restore_oldest_backup(app: Path, dry_run: bool) -> Path | None:
     backups = find_app_backups(app)
     if not backups:
         raise SystemExit(f"No Claude backup found in {app.parent}: {BACKUP_GLOB}")
 
-    backup = backups[0]
-    extra_backups = backups[1:]
+    backup = select_compatible_backup(app, backups)
+    if backup is None:
+        print(
+            "No backup matches the currently installed patched build; "
+            "keeping the current Claude.app to prevent a cross-version downgrade."
+        )
+        if read_patch_marker(app) is None:
+            remove_backups(backups, dry_run, "unmatched")
+        return None
+
+    extra_backups = [path for path in backups if path != backup]
     stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
     current_tmp = app.with_name(f"Claude.restore-current-{stamp}.app")
 
     if dry_run:
         if app.exists():
             print(f"[dry-run] Would move current app {app} -> {current_tmp}")
-        print(f"[dry-run] Would restore oldest backup {backup} -> {app}")
+        print(f"[dry-run] Would restore matching backup {backup} -> {app}")
         for extra_backup in extra_backups:
             print(f"[dry-run] Would delete extra backup: {extra_backup}")
         return backup
@@ -2354,7 +2798,7 @@ def restore_oldest_backup(app: Path, dry_run: bool) -> Path:
         shutil.move(str(app), str(current_tmp))
 
     try:
-        print(f"Restoring oldest backup: {backup}")
+        print(f"Restoring matching backup: {backup}")
         shutil.move(str(backup), str(app))
     except Exception:
         if current_tmp.exists() and not app.exists():
@@ -2425,15 +2869,22 @@ def verify_online_locale_patch(app: Path, lang_code: str) -> None:
     print(f"Verified online locale patch in {asar_target}: {lang_code}")
 
 
-def verify(app: Path, lang_code: str, *, expect_online_patch: bool = True) -> None:
+def verify(
+    app: Path,
+    lang_code: str,
+    *,
+    expect_online_patch: bool = True,
+    verify_asar: bool = True,
+) -> None:
     start = time.perf_counter()
-    frontend = app / FRONTEND_I18N_REL / f"{lang_code}.json"
+    frontend = find_frontend_i18n_dir(app) / f"{lang_code}.json"
     data = load_json(frontend)
     values = [v for v in data.values() if isinstance(v, str)]
     chinese = sum(1 for v in values if re.search(r"[\u4e00-\u9fff]", v))
     print(f"Verified frontend {lang_code} JSON: {chinese}/{len(values)} strings contain Chinese")
 
-    verify_electron_asar_integrity(app)
+    if verify_asar:
+        verify_electron_asar_integrity(app)
     if expect_online_patch:
         verify_online_locale_patch(app, lang_code)
 
@@ -2458,6 +2909,115 @@ def verify(app: Path, lang_code: str, *, expect_online_patch: bool = True) -> No
     log(f"Verification finished in {elapsed_since(start)}")
 
 
+def doctor_report(app: Path, lang_code: str) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "schema": 1,
+        "app": str(app),
+        "patchRelease": get_patch_release(),
+        "language": lang_code,
+        "basicCompatible": False,
+        "fullCompatible": False,
+        "checks": {},
+    }
+    checks: dict[str, Any] = report["checks"]
+    if not app.exists():
+        checks["app"] = {"ok": False, "error": "Claude.app not found"}
+        return report
+    try:
+        report["identity"] = get_app_identity(app)
+        report["marker"] = read_patch_marker(app)
+        checks["app"] = {"ok": True}
+    except (Exception, SystemExit) as exc:
+        checks["app"] = {"ok": False, "error": str(exc)}
+        return report
+
+    try:
+        i18n_dir = find_frontend_i18n_dir(app)
+        en_data = load_json(i18n_dir / "en-US.json")
+        checks["frontendI18n"] = {
+            "ok": isinstance(en_data, dict),
+            "path": str(i18n_dir),
+            "englishKeys": len(en_data) if isinstance(en_data, dict) else 0,
+        }
+    except (Exception, SystemExit) as exc:
+        checks["frontendI18n"] = {"ok": False, "error": str(exc)}
+
+    try:
+        js_files = find_frontend_js_files(app)
+        scored_arrays = 0
+        best_score = -1
+        for path in js_files:
+            text = path.read_text(encoding="utf-8")
+            for match in LOCALE_ARRAY_RE.finditer(text):
+                locales = parse_locale_array(match.group(0))
+                if locales is None:
+                    continue
+                context = text[max(0, match.start() - 160) : min(len(text), match.end() + 80)]
+                score = locale_array_score(locales, context)
+                if score >= 0:
+                    scored_arrays += 1
+                    best_score = max(best_score, score)
+        checks["frontendBundles"] = {
+            "ok": bool(js_files) and scored_arrays > 0,
+            "count": len(js_files),
+            "whitelistCandidates": scored_arrays,
+            "bestWhitelistScore": best_score,
+        }
+    except (Exception, SystemExit) as exc:
+        checks["frontendBundles"] = {"ok": False, "error": str(exc)}
+
+    try:
+        asar_path = app / APP_ASAR_REL
+        data = asar_path.read_bytes()
+        header_size, _header_string, header = read_asar_header(data, asar_path)
+        target = find_main_process_asar_target(data, header_size, header)
+        checks["asarFullPatch"] = {"ok": True, "mainBundle": target}
+    except (Exception, SystemExit) as exc:
+        checks["asarFullPatch"] = {"ok": False, "error": str(exc)}
+
+    report["basicCompatible"] = bool(
+        checks.get("frontendI18n", {}).get("ok")
+        and checks.get("frontendBundles", {}).get("ok")
+    )
+    report["fullCompatible"] = bool(
+        report["basicCompatible"] and checks.get("asarFullPatch", {}).get("ok")
+    )
+    return report
+
+
+def prepare_patched_app(
+    source_app: Path,
+    patched_app: Path,
+    lang_code: str,
+    skip_asar_patch: bool,
+) -> None:
+    copy_app(source_app, patched_app)
+    primary_bundle = patch_language_whitelist(patched_app, lang_code)
+    patch_hardcoded_frontend_strings(patched_app, lang_code)
+    patch_language_display_names(patched_app, primary_bundle)
+    if skip_asar_patch:
+        print("Skipping every app.asar and binary-integrity patch (--skip-asar-patch)")
+    else:
+        patch_online_locale_preload(patched_app, lang_code)
+        patch_online_locale_main_process(patched_app, lang_code)
+        patch_hardcoded_main_process_menu_labels(patched_app, lang_code)
+        patch_custom3p_model_validation(patched_app)
+        patch_model_picker_strings(patched_app, lang_code)
+    merge_frontend_locale(patched_app, lang_code)
+    install_desktop_locale(patched_app, lang_code)
+    install_statsig_locale(patched_app, lang_code)
+    patch_mode = "safe" if skip_asar_patch else "full"
+    write_patch_marker(patched_app, source_app, lang_code, patch_mode)
+    resign_app(patched_app)
+    clear_quarantine(patched_app)
+    verify(
+        patched_app,
+        lang_code,
+        expect_online_patch=not skip_asar_patch,
+        verify_asar=not skip_asar_patch,
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Patch Claude Desktop with Chinese language resources.")
     parser.add_argument("--app", type=Path, default=APP_DEFAULT, help="Path to Claude.app")
@@ -2465,11 +3025,16 @@ def main() -> int:
     parser.add_argument("--lang", choices=["zh-CN", "zh-TW", "zh-HK"], default="zh-CN", help="Language code to install (default: zh-CN)")
     parser.add_argument("--dry-run", action="store_true", help="Prepare and verify a patched temp app, but do not replace /Applications/Claude.app")
     parser.add_argument("--launch", action="store_true", help="Launch Claude after installation")
-    parser.add_argument("--restore", action="store_true", help="Restore the oldest macOS app backup and delete other backups")
+    parser.add_argument("--restore", action="store_true", help="Restore the identity-matching macOS app backup and delete other backups")
+    parser.add_argument("--doctor", action="store_true", help="Inspect this Claude build without changing it")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable output with --doctor")
+    parser.add_argument("--no-auto-repair", action="store_true", help="Do not install the update auto-repair service")
+    parser.add_argument("--remove-auto-repair", action="store_true", help="Remove the update auto-repair service and exit")
+    parser.add_argument("--maintenance-run", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument(
         "--restore-if-backup-exists",
         action="store_true",
-        help="Restore the oldest macOS app backup if one exists, otherwise continue without error",
+        help="Restore the identity-matching macOS app backup if one exists, otherwise continue without error",
     )
     parser.add_argument("--skip-asar-patch", action="store_true", help="Skip app.asar and binary integrity patches (safe mode)")
     parser.add_argument(
@@ -2493,6 +3058,22 @@ def main() -> int:
         help="CC Switch skills directory (default: USER_HOME/.cc-switch/skills)",
     )
     args = parser.parse_args()
+
+    if args.doctor:
+        report = doctor_report(args.app, args.lang)
+        if args.json:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            print(f"Claude: {report.get('identity', {})}")
+            print(f"Basic localization compatible: {report['basicCompatible']}")
+            print(f"Full app.asar patch compatible: {report['fullCompatible']}")
+            for name, result in report["checks"].items():
+                print(f"  {name}: {result}")
+        return 0 if report["basicCompatible"] else 2
+
+    if args.remove_auto_repair:
+        remove_macos_auto_repair(dry_run=args.dry_run)
+        return 0
 
     if args.set_auto_updates:
         set_auto_updates(
@@ -2519,26 +3100,36 @@ def main() -> int:
         return 0
 
     try:
-        in_applications = args.app.resolve().as_posix().startswith("/Applications/")
+        in_applications = path_is_within(args.app.resolve(), Path("/Applications").resolve())
     except Exception:
-        in_applications = str(args.app).startswith("/Applications/")
+        in_applications = path_is_within(args.app.absolute(), Path("/Applications"))
     if os.geteuid() != 0 and in_applications and not args.dry_run:
         print("This usually needs sudo because /Applications is protected.", file=sys.stderr)
 
     if args.restore:
+        remove_macos_auto_repair(dry_run=args.dry_run)
         if args.dry_run:
             print("[dry-run] Claude will not be quit.")
         else:
             quit_claude()
-        restored = restore_oldest_backup(args.app, args.dry_run)
+        if not find_app_backups(args.app):
+            if read_patch_marker(args.app):
+                raise SystemExit("This app is marked as patched, but its matching original backup is missing.")
+            restored = None
+            print("No patch backup exists; keeping the current unmarked Claude.app.")
+        else:
+            restored = restore_oldest_backup(args.app, args.dry_run)
+        if restored is None and read_patch_marker(args.app):
+            raise SystemExit("No compatible original backup was found; refusing an unsafe restore.")
         if args.dry_run:
             print(f"[dry-run] Would set Claude config locale under: {args.user_home} to en-US")
         else:
             set_user_locale(args.user_home, "en-US")
-            print(f"Restored from backup: {restored}")
+            if restored is not None:
+                print(f"Restored from backup: {restored}")
             if args.launch:
                 run(["open", "-a", str(args.app)], check=False)
-        print("Done. Claude Desktop has been restored to the oldest backup.")
+        print("Done. Claude Desktop is unpatched and automatic repair is disabled.")
         return 0
 
     if args.restore_if_backup_exists:
@@ -2550,9 +3141,12 @@ def main() -> int:
         else:
             quit_claude()
         restored = restore_oldest_backup(args.app, args.dry_run)
-        if not args.dry_run:
+        if not args.dry_run and restored is not None:
             print(f"Restored from backup before install: {restored}")
-        print("Done. Existing Chinese patch has been cleared before install.")
+        if restored is None:
+            print("Kept the current official build and discarded only incompatible old backups.")
+        else:
+            print("Done. Existing Chinese patch has been cleared before install.")
         return 0
 
     lang_code = args.lang
@@ -2567,48 +3161,62 @@ def main() -> int:
         raise SystemExit(f"Claude.app not found: {args.app}")
     require_virtualization_entitlement(args.app)
 
+    patch_mode = "safe" if args.skip_asar_patch else "full"
+    if args.maintenance_run and patch_is_current(args.app, lang_code, patch_mode):
+        print("The installed Claude build is already patched; maintenance is a no-op.")
+        return 0
+
     if args.dry_run:
         print("[dry-run] Claude will not be quit.")
     else:
         quit_claude()
     tmp_root = Path(tempfile.mkdtemp(prefix=f"claude-{lang_code}-patch."))
     patched_app = tmp_root / "Claude.app"
-
-    copy_app(args.app, patched_app)
-    patch_language_whitelist(patched_app, lang_code)
-    patch_hardcoded_frontend_strings(patched_app, lang_code)
-    patch_language_display_names(patched_app)
-    if args.skip_asar_patch:
-        print("Skipping online claude.ai locale preload patch (--skip-asar-patch)")
-    else:
-        patch_online_locale_preload(patched_app, lang_code)
-        patch_online_locale_main_process(patched_app, lang_code)
-    if args.skip_asar_patch:
-        print("Applying length-preserving main-process menu label patch (--skip-asar-patch)")
-        patch_length_preserving_main_process_menu_labels(patched_app, lang_code)
-    else:
-        patch_hardcoded_main_process_menu_labels(patched_app, lang_code)
-    if args.skip_asar_patch:
-        print("Skipping 3P model validation patch (--skip-asar-patch)")
-    else:
-        patch_custom3p_model_validation(patched_app)
-        patch_model_picker_strings(patched_app, lang_code)
-    merge_frontend_locale(patched_app, lang_code)
-    install_desktop_locale(patched_app, lang_code)
-    install_statsig_locale(patched_app, lang_code)
-    resign_app(patched_app)
-    clear_quarantine(patched_app)
-    if args.dry_run:
-        print(f"[dry-run] Would set Claude config locale under: {args.user_home}")
-    else:
-        set_user_locale(args.user_home, lang_code)
-    verify(patched_app, lang_code, expect_online_patch=not args.skip_asar_patch)
-
-    backup = backup_and_replace(args.app, patched_app, args.dry_run)
-    if not args.dry_run:
-        print(f"Backup kept at: {backup}")
-        if args.launch:
-            run(["open", "-a", str(args.app)], check=False)
+    try:
+        effective_skip_asar = args.skip_asar_patch
+        try:
+            prepare_patched_app(args.app, patched_app, lang_code, effective_skip_asar)
+        except SystemExit as full_error:
+            if effective_skip_asar:
+                raise
+            print(
+                "Full app.asar patch is not compatible with this Claude build; "
+                "retrying the verified basic localization mode."
+            )
+            print(f"Full-mode compatibility detail: {full_error}")
+            if patched_app.exists():
+                remove_path(patched_app)
+            try:
+                prepare_patched_app(args.app, patched_app, lang_code, True)
+            except SystemExit as safe_error:
+                raise SystemExit(
+                    "This Claude build failed both full and basic localization checks. "
+                    f"Full mode: {full_error}; basic mode: {safe_error}"
+                ) from safe_error
+            effective_skip_asar = True
+            patch_mode = "safe"
+            print("Compatibility fallback succeeded; installed basic localization without changing app.asar.")
+        backup = backup_and_replace(args.app, patched_app, args.dry_run)
+        if args.dry_run:
+            print(f"[dry-run] Would set Claude config locale under: {args.user_home}")
+        else:
+            print(f"Backup kept at: {backup}")
+            set_user_locale(args.user_home, lang_code)
+            if not args.no_auto_repair and not args.maintenance_run:
+                try:
+                    install_macos_auto_repair(
+                        args.app,
+                        args.user_home,
+                        lang_code,
+                        patch_mode,
+                    )
+                except SystemExit as exc:
+                    print(f"Warning: patch installed, but automatic update repair could not be enabled: {exc}")
+            if args.launch:
+                run(["open", "-a", str(args.app)], check=False)
+    finally:
+        if tmp_root.exists():
+            remove_path(tmp_root)
 
     print(f"Done. Select Language -> {label} in Claude if it is not already selected.")
     return 0

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -2634,6 +2634,11 @@ def install_macos_auto_repair(
             str(AUTO_REPAIR_CONFIG),
         ],
         "RunAtLoad": True,
+        # Event trigger: launchd fires the job as soon as the official updater
+        # replaces Info.plist (the .app swap touches it). The settle/debounce
+        # logic in macos_auto_repair.py keeps mid-update runs harmless, and
+        # StartInterval remains as the polling fallback if a watch is missed.
+        "WatchPaths": [str(app.resolve() / "Contents/Info.plist")],
         "StartInterval": AUTO_REPAIR_INTERVAL_SECONDS,
         "ThrottleInterval": 60,
         "ProcessType": "Background",
@@ -2657,8 +2662,8 @@ def install_macos_auto_repair(
             "Failed to load the macOS auto-repair service. launchctl output:\n" + result.stdout
         )
     print(
-        f"Installed update auto-repair service ({AUTO_REPAIR_INTERVAL_SECONDS // 60}-minute checks): "
-        f"{AUTO_REPAIR_LABEL}"
+        f"Installed update auto-repair service (update-triggered, "
+        f"{AUTO_REPAIR_INTERVAL_SECONDS // 60}-minute fallback checks): {AUTO_REPAIR_LABEL}"
     )
 
 
@@ -2971,7 +2976,23 @@ def doctor_report(app: Path, lang_code: str) -> dict[str, Any]:
         data = asar_path.read_bytes()
         header_size, _header_string, header = read_asar_header(data, asar_path)
         target = find_main_process_asar_target(data, header_size, header)
-        checks["asarFullPatch"] = {"ok": True, "mainBundle": target}
+        # Selecting a bundle is not enough: the legacy-path fallback can return
+        # a bundle whose injection anchor is gone. Verify the anchor (or an
+        # already-applied patch marker) actually exists before reporting ok.
+        entry = get_asar_file_entry(header, target)
+        content = read_asar_entry_content(data, header_size, entry, target)
+        anchor_ok = ONLINE_LOCALE_MAIN_MARKER.encode("utf-8") in content
+        if not anchor_ok:
+            try:
+                text = content.decode("utf-8")
+            except UnicodeDecodeError:
+                text = ""
+            anchor_ok = find_main_view_dom_ready_handler(text) is not None
+        checks["asarFullPatch"] = {
+            "ok": anchor_ok,
+            "mainBundle": target,
+            **({} if anchor_ok else {"error": "main view dom-ready anchor not found"}),
+        }
     except (Exception, SystemExit) as exc:
         checks["asarFullPatch"] = {"ok": False, "error": str(exc)}
 
@@ -3168,6 +3189,11 @@ def main() -> int:
 
     if args.dry_run:
         print("[dry-run] Claude will not be quit.")
+    elif args.maintenance_run:
+        # The auto-repair daemon runs outside the user's GUI session, where a
+        # bare osascript cannot deliver the quit AppleEvent; the controller
+        # already quit Claude via `launchctl asuser` before spawning us.
+        pass
     else:
         quit_claude()
     tmp_root = Path(tempfile.mkdtemp(prefix=f"claude-{lang_code}-patch."))

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import plistlib
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "patch_claude_zh_cn",
+    ROOT / "scripts/patch_claude_zh_cn.py",
+)
+assert SPEC and SPEC.loader
+patcher = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(patcher)
+
+
+def make_app(root: Path, version: str, build: str, asar: bytes = b"official-asar") -> Path:
+    app = root / "Claude.app"
+    resources = app / "Contents/Resources"
+    resources.mkdir(parents=True)
+    with (app / "Contents/Info.plist").open("wb") as f:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "com.anthropic.claudefordesktop",
+                "CFBundleShortVersionString": version,
+                "CFBundleVersion": build,
+            },
+            f,
+        )
+    (resources / "app.asar").write_bytes(asar)
+    return app
+
+
+def make_frontend(app: Path, asset_version: str = "v2") -> tuple[Path, Path]:
+    i18n = app / "Contents/Resources/ion-dist/locales"
+    assets = app / f"Contents/Resources/ion-dist/assets/{asset_version}"
+    i18n.mkdir(parents=True)
+    assets.mkdir(parents=True)
+    (i18n / "en-US.json").write_text(
+        json.dumps({"hello": "Hello", "new": "New upstream text"}),
+        encoding="utf-8",
+    )
+    bundle = assets / "app-HASH.js"
+    bundle.write_text(
+        "const languageOptions = ['fr-FR', 'en-US', 'nl-NL', 'de-DE', "
+        "'ja-JP', 'ko-KR', 'id-ID'];",
+        encoding="utf-8",
+    )
+    return i18n, bundle
+
+
+def write_minimal_asar(app: Path) -> None:
+    header = {
+        "files": {
+            "empty.js": {
+                "size": 0,
+                "offset": "0",
+                "integrity": patcher.calculate_file_integrity(b""),
+            },
+            "next.js": {
+                "size": 4,
+                "offset": "0",
+                "integrity": patcher.calculate_file_integrity(b"NEXT"),
+            },
+        }
+    }
+    header_string = json.dumps(header, separators=(",", ":"))
+    (app / patcher.APP_ASAR_REL).write_bytes(
+        patcher.encode_asar_header_dynamic(header_string) + b"NEXT"
+    )
+
+
+def write_single_file_asar(app: Path, file_path: str, content: bytes) -> None:
+    files: dict[str, object] = {}
+    cursor = files
+    parts = file_path.split("/")
+    for part in parts[:-1]:
+        node: dict[str, object] = {"files": {}}
+        cursor[part] = node
+        cursor = node["files"]  # type: ignore[assignment]
+    cursor[parts[-1]] = {
+        "size": len(content),
+        "offset": "0",
+        "integrity": patcher.calculate_file_integrity(content),
+    }
+    header_string = json.dumps({"files": files}, separators=(",", ":"))
+    (app / patcher.APP_ASAR_REL).write_bytes(
+        patcher.encode_asar_header_dynamic(header_string) + content
+    )
+
+
+class PatcherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_semantic_whitelist_supports_v2_and_preserves_upstream_locales(self) -> None:
+        app = make_app(self.root, "2.0.0", "200")
+        _i18n, bundle = make_frontend(app, "v2")
+
+        selected = patcher.patch_language_whitelist(app, "zh-CN")
+        patcher.patch_language_display_names(app, selected)
+        text = bundle.read_text(encoding="utf-8")
+
+        self.assertEqual(selected, bundle)
+        self.assertIn('"nl-NL"', text)
+        self.assertEqual(text.count('"zh-CN"'), 2)  # whitelist plus display-name runtime patch
+        self.assertIn("__claudeZhLabelPatch", text)
+
+    def test_frontend_merge_discovers_locales_and_falls_back_to_current_english(self) -> None:
+        app = make_app(self.root, "2.0.0", "200")
+        i18n, _bundle = make_frontend(app)
+        resource_root = self.root / "pack"
+        resource_root.mkdir()
+        (resource_root / "frontend-zh-CN.json").write_text(
+            json.dumps({"hello": "你好", "removed": "旧字段"}),
+            encoding="utf-8",
+        )
+
+        with mock.patch.object(patcher, "RESOURCES", resource_root):
+            translated, fallback, extra = patcher.merge_frontend_locale(app, "zh-CN")
+
+        merged = json.loads((i18n / "zh-CN.json").read_text(encoding="utf-8"))
+        self.assertEqual(merged, {"hello": "你好", "new": "New upstream text"})
+        self.assertEqual((translated, fallback, extra), (1, 1, 1))
+
+    def test_cross_version_backup_is_never_restored_into_official_update(self) -> None:
+        current = make_app(self.root, "2.0.0", "200", b"v2")
+        stale_root = self.root / "stale"
+        stale = make_app(stale_root, "1.0.0", "100", b"v1")
+        stale_backup = self.root / "Claude.backup-before-zh-CN-20260101-000000.app"
+        shutil.move(str(stale), str(stale_backup))
+
+        restored = patcher.restore_oldest_backup(current, dry_run=False)
+
+        self.assertIsNone(restored)
+        self.assertEqual(patcher.get_app_identity(current)["version"], "2.0.0")
+        self.assertFalse(stale_backup.exists())
+
+    def test_matching_marker_restores_exact_source_backup(self) -> None:
+        source_root = self.root / "source"
+        source = make_app(source_root, "2.0.0", "200", b"source-v2")
+        current = make_app(self.root, "2.0.0", "200", b"patched-v2")
+        backup = self.root / "Claude.backup-before-zh-CN-20260101-000000.app"
+        shutil.copytree(source, backup)
+        patcher.write_patch_marker(current, source, "zh-CN", "safe")
+
+        restored = patcher.restore_oldest_backup(current, dry_run=False)
+
+        self.assertEqual(restored, backup)
+        self.assertEqual((current / patcher.APP_ASAR_REL).read_bytes(), b"source-v2")
+        self.assertIsNone(patcher.read_patch_marker(current))
+
+    def test_current_marker_detects_in_place_asar_replacement(self) -> None:
+        app = make_app(self.root, "2.0.0", "200", b"patched-asar")
+        i18n, _bundle = make_frontend(app)
+        patcher.patch_language_whitelist(app, "zh-CN")
+        (i18n / "zh-CN.json").write_text('{"hello":"你好"}', encoding="utf-8")
+        patcher.write_patch_marker(app, app, "zh-CN", "full")
+
+        self.assertTrue(patcher.patch_is_current(app, "zh-CN", "full"))
+        (app / patcher.APP_ASAR_REL).write_bytes(b"upstream-replaced-asar")
+        self.assertFalse(patcher.patch_is_current(app, "zh-CN", "full"))
+
+    def test_in_place_update_discards_stale_marker_and_old_backup(self) -> None:
+        old_root = self.root / "old"
+        old = make_app(old_root, "1.0.0", "100", b"old-official")
+        current = make_app(self.root, "2.0.0", "200", b"new-official")
+        stale_backup = self.root / "Claude.backup-before-zh-CN-20260101-000000.app"
+        shutil.copytree(old, stale_backup)
+        patcher.write_patch_marker(current, old, "zh-CN", "full")
+
+        prepared_root = self.root / "prepared"
+        prepared = make_app(prepared_root, "2.0.0", "200", b"new-patched")
+        patcher.backup_and_replace(current, prepared, dry_run=False)
+
+        backups = patcher.find_app_backups(current)
+        self.assertEqual(len(backups), 1)
+        self.assertEqual((backups[0] / patcher.APP_ASAR_REL).read_bytes(), b"new-official")
+        self.assertIsNone(patcher.read_patch_marker(backups[0]))
+        self.assertFalse(stale_backup.exists())
+        self.assertEqual((current / patcher.APP_ASAR_REL).read_bytes(), b"new-patched")
+
+    def test_commit_failure_rolls_original_app_back(self) -> None:
+        original = make_app(self.root, "2.0.0", "200", b"original")
+        patched_root = self.root / "prepared"
+        patched = make_app(patched_root, "2.0.0", "200", b"patched")
+        real_move = shutil.move
+        calls = 0
+
+        def flaky_move(src: str, dst: str) -> str:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("injected commit failure")
+            return real_move(src, dst)
+
+        with mock.patch.object(patcher.shutil, "move", side_effect=flaky_move):
+            with self.assertRaisesRegex(OSError, "injected"):
+                patcher.backup_and_replace(original, patched, dry_run=False)
+
+        self.assertTrue(original.exists())
+        self.assertEqual((original / patcher.APP_ASAR_REL).read_bytes(), b"original")
+        self.assertEqual(patcher.find_app_backups(original), [])
+
+    def test_safe_mode_never_calls_asar_patchers(self) -> None:
+        source = self.root / "source.app"
+        target = self.root / "target.app"
+        structural_names = [
+            "patch_online_locale_preload",
+            "patch_online_locale_main_process",
+            "patch_hardcoded_main_process_menu_labels",
+            "patch_custom3p_model_validation",
+            "patch_model_picker_strings",
+        ]
+        mocks = {name: mock.patch.object(patcher, name) for name in structural_names}
+        started = [item.start() for item in mocks.values()]
+        self.addCleanup(lambda: [item.stop() for item in mocks.values()])
+        baseline = [
+            mock.patch.object(patcher, "copy_app"),
+            mock.patch.object(patcher, "patch_language_whitelist", return_value=Path("bundle.js")),
+            mock.patch.object(patcher, "patch_hardcoded_frontend_strings"),
+            mock.patch.object(patcher, "patch_language_display_names"),
+            mock.patch.object(patcher, "merge_frontend_locale"),
+            mock.patch.object(patcher, "install_desktop_locale"),
+            mock.patch.object(patcher, "install_statsig_locale"),
+            mock.patch.object(patcher, "write_patch_marker"),
+            mock.patch.object(patcher, "resign_app"),
+            mock.patch.object(patcher, "clear_quarantine"),
+            mock.patch.object(patcher, "verify"),
+        ]
+        baseline_mocks = [item.start() for item in baseline]
+        self.addCleanup(lambda: [item.stop() for item in baseline])
+
+        patcher.prepare_patched_app(source, target, "zh-CN", True)
+
+        for structural_mock in started:
+            structural_mock.assert_not_called()
+        baseline_mocks[-1].assert_called_once_with(
+            target,
+            "zh-CN",
+            expect_online_patch=False,
+            verify_asar=False,
+        )
+
+    def test_growing_empty_asar_entry_moves_following_shared_offset(self) -> None:
+        app = make_app(self.root, "2.0.0", "200")
+        write_minimal_asar(app)
+
+        with mock.patch.object(patcher, "update_electron_asar_integrity"):
+            patcher.replace_asar_file_content(app, "empty.js", b"PATCH")
+
+        data = (app / patcher.APP_ASAR_REL).read_bytes()
+        header_size, _header_string, header = patcher.read_asar_header(data, app / patcher.APP_ASAR_REL)
+        empty_entry = patcher.get_asar_file_entry(header, "empty.js")
+        next_entry = patcher.get_asar_file_entry(header, "next.js")
+        self.assertEqual(
+            patcher.read_asar_entry_content(data, header_size, empty_entry, "empty.js"),
+            b"PATCH",
+        )
+        self.assertEqual(
+            patcher.read_asar_entry_content(data, header_size, next_entry, "next.js"),
+            b"NEXT",
+        )
+        self.assertEqual(int(next_entry["offset"]), 5)
+
+    def test_hashed_main_process_chunk_is_discovered_dynamically(self) -> None:
+        app = make_app(self.root, "2.0.0", "200")
+        hashed_path = ".vite/build/index.chunk-DINfBFDm.js"
+        write_single_file_asar(
+            app,
+            hashed_path,
+            f"/*{patcher.ONLINE_LOCALE_MAIN_MARKER}*/".encode(),
+        )
+
+        asar_path = app / patcher.APP_ASAR_REL
+        data = asar_path.read_bytes()
+        header_size, _header_string, header = patcher.read_asar_header(data, asar_path)
+
+        self.assertEqual(
+            patcher.find_main_process_asar_target(data, header_size, header),
+            hashed_path,
+        )
+
+    def test_resource_manifests_match_actual_key_counts(self) -> None:
+        manifests = {
+            "zh-CN": "manifest.json",
+            "zh-TW": "manifest-zh-TW.json",
+            "zh-HK": "manifest-zh-HK.json",
+        }
+        for language, manifest_name in manifests.items():
+            with self.subTest(language=language):
+                manifest = json.loads((ROOT / "resources" / manifest_name).read_text(encoding="utf-8"))
+                frontend = json.loads(
+                    (ROOT / "resources" / f"frontend-{language}.json").read_text(encoding="utf-8")
+                )
+                desktop = json.loads(
+                    (ROOT / "resources" / f"desktop-{language}.json").read_text(encoding="utf-8")
+                )
+                self.assertEqual(manifest["language"], language)
+                self.assertEqual(manifest["frontend_strings"], len(frontend))
+                self.assertEqual(manifest["desktop_shell_strings"], len(desktop))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_patcher.py
+++ b/tests/test_patcher.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import plistlib
 import shutil
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,6 +19,19 @@ SPEC = importlib.util.spec_from_file_location(
 assert SPEC and SPEC.loader
 patcher = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(patcher)
+# macos_auto_repair does `import patch_claude_zh_cn`; register the already
+# loaded instance so both modules share state and mock.patch.object works.
+sys.modules["patch_claude_zh_cn"] = patcher
+
+auto_repair = None
+if sys.platform != "win32":  # fcntl/pwd imports are Unix-only
+    AUTO_REPAIR_SPEC = importlib.util.spec_from_file_location(
+        "macos_auto_repair",
+        ROOT / "scripts/macos_auto_repair.py",
+    )
+    assert AUTO_REPAIR_SPEC and AUTO_REPAIR_SPEC.loader
+    auto_repair = importlib.util.module_from_spec(AUTO_REPAIR_SPEC)
+    AUTO_REPAIR_SPEC.loader.exec_module(auto_repair)
 
 
 def make_app(root: Path, version: str, build: str, asar: bytes = b"official-asar") -> Path:
@@ -291,6 +305,26 @@ class PatcherTests(unittest.TestCase):
             hashed_path,
         )
 
+    def test_doctor_flags_selected_bundle_with_missing_anchor(self) -> None:
+        # The legacy-path fallback in find_main_process_asar_target can select
+        # a bundle whose dom-ready anchor is gone; doctor must not report that
+        # as full-compatible (upstream-watch relies on this signal).
+        app = make_app(self.root, "9.9.9", "999")
+        make_frontend(app)
+        write_single_file_asar(app, ".vite/build/index.js", b"console.log('no anchor');")
+        report = patcher.doctor_report(app, "zh-CN")
+        self.assertTrue(report["basicCompatible"])
+        self.assertFalse(report["checks"]["asarFullPatch"]["ok"])
+        self.assertFalse(report["fullCompatible"])
+
+        anchored = b'a.webContents.on("dom-ready",()=>{t.track("main_view_dom_ready")});'
+        app2 = make_app(self.root / "anchored", "9.9.9", "999")
+        make_frontend(app2)
+        write_single_file_asar(app2, ".vite/build/index.js", anchored)
+        report2 = patcher.doctor_report(app2, "zh-CN")
+        self.assertTrue(report2["checks"]["asarFullPatch"]["ok"])
+        self.assertTrue(report2["fullCompatible"])
+
     def test_resource_manifests_match_actual_key_counts(self) -> None:
         manifests = {
             "zh-CN": "manifest.json",
@@ -309,6 +343,100 @@ class PatcherTests(unittest.TestCase):
                 self.assertEqual(manifest["language"], language)
                 self.assertEqual(manifest["frontend_strings"], len(frontend))
                 self.assertEqual(manifest["desktop_shell_strings"], len(desktop))
+
+
+@unittest.skipIf(sys.platform == "win32", "macos_auto_repair is Unix-only (fcntl/pwd)")
+class AutoRepairTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    def test_log_rotation_only_when_over_cap(self) -> None:
+        log_path = self.tmp / "auto-repair.log"
+        rotated = self.tmp / "auto-repair.log.old"
+        with mock.patch.object(patcher, "AUTO_REPAIR_LOG", log_path):
+            auto_repair.rotate_log_if_needed()  # missing file is a no-op
+            log_path.write_bytes(b"x" * (auto_repair.LOG_ROTATE_BYTES - 1))
+            auto_repair.rotate_log_if_needed()
+            self.assertTrue(log_path.exists())
+            self.assertFalse(rotated.exists())
+            log_path.write_bytes(b"x" * auto_repair.LOG_ROTATE_BYTES)
+            auto_repair.rotate_log_if_needed()
+            self.assertFalse(log_path.exists())
+            self.assertTrue(rotated.exists())
+
+    def test_claude_is_running_uses_anchored_bundle_prefix(self) -> None:
+        app = Path("/Applications/Claude.app")
+        with mock.patch.object(auto_repair.subprocess, "run") as run:
+            run.return_value = mock.Mock(returncode=0)
+            self.assertTrue(auto_repair.claude_is_running(app))
+        argv = run.call_args[0][0]
+        self.assertEqual(argv[:2], ["/usr/bin/pgrep", "-f"])
+        pattern = argv[2]
+        # Anchored to argv[0] and scoped inside the bundle: unrelated commands
+        # that merely mention the path in an argument must not match.
+        self.assertTrue(pattern.startswith("^"))
+        self.assertIn("Contents/", pattern)
+        self.assertIn(r"Claude\.app", pattern)
+
+    def test_failure_backoff_quadrants(self) -> None:
+        fingerprint = {"identity": {"version": "1.0"}, "asarSize": 1}
+        base = {
+            "failedFingerprint": fingerprint,
+            "patchRelease": "1.4.2",
+            "failedAt": 1_000_000.0,
+        }
+        with mock.patch.object(auto_repair.time, "time", return_value=1_000_000.0 + 60):
+            self.assertTrue(auto_repair.failure_is_backed_off(base, fingerprint, "1.4.2"))
+            self.assertFalse(
+                auto_repair.failure_is_backed_off(base, {"identity": {}, "asarSize": 2}, "1.4.2")
+            )
+            self.assertFalse(auto_repair.failure_is_backed_off(base, fingerprint, "1.4.3"))
+            self.assertFalse(
+                auto_repair.failure_is_backed_off({**base, "failedAt": "bad"}, fingerprint, "1.4.2")
+            )
+        after = 1_000_000.0 + auto_repair.FAILURE_RETRY_SECONDS + 1
+        with mock.patch.object(auto_repair.time, "time", return_value=after):
+            self.assertFalse(auto_repair.failure_is_backed_off(base, fingerprint, "1.4.2"))
+
+    def test_quit_claude_for_user_delivers_via_launchctl_asuser(self) -> None:
+        app = Path("/Applications/Claude.app")
+        calls: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(argv)
+            return mock.Mock(returncode=0)
+
+        running = iter([True, False])  # running before quit, gone afterwards
+        with (
+            mock.patch.object(auto_repair, "claude_is_running", lambda _: next(running)),
+            mock.patch.object(auto_repair.subprocess, "run", side_effect=fake_run),
+            mock.patch.object(auto_repair.pwd, "getpwuid") as getpwuid,
+            mock.patch.object(Path, "stat") as stat,
+        ):
+            stat.return_value = mock.Mock(st_uid=501)
+            getpwuid.return_value = mock.Mock(pw_name="tester")
+            self.assertTrue(auto_repair.quit_claude_for_user(app, Path("/Users/tester")))
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][:3], ["/bin/launchctl", "asuser", "501"])
+        self.assertIn("/usr/bin/osascript", calls[0])
+        self.assertIn(
+            f'tell application id "{auto_repair.CLAUDE_BUNDLE_ID}" to quit', calls[0]
+        )
+
+    def test_quit_claude_for_user_reports_lingering_process(self) -> None:
+        app = Path("/Applications/Claude.app")
+        with (
+            mock.patch.object(auto_repair, "claude_is_running", return_value=True),
+            mock.patch.object(auto_repair.subprocess, "run") as run,
+            mock.patch.object(auto_repair.pwd, "getpwuid") as getpwuid,
+            mock.patch.object(Path, "stat") as stat,
+            mock.patch.object(auto_repair, "QUIT_WAIT_SECONDS", 0),
+        ):
+            stat.return_value = mock.Mock(st_uid=501)
+            getpwuid.return_value = mock.Mock(pw_name="tester")
+            run.return_value = mock.Mock(returncode=0)
+            self.assertFalse(auto_repair.quit_claude_for_user(app, Path("/Users/tester")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 解决的两个长期问题

1. **Claude 客户端自动更新后汉化丢失,不会自动恢复**——补丁全部位于 `.app` 内部,Squirrel 更新整体替换后汉化必然消失;此前仅有的"禁用自动更新"是默认不启用的可选项,多数用户无保护。
2. **客户端内部结构变化后补丁失效,连手动汉化都无法完成**——脚本依赖硬编码锚点(精确 11 语言白名单正则、`ion-dist/assets/v1` 固定路径、minified 符号名、精确标点),任一失配即 `SystemExit` 全盘中止(历史案例:efd3614、a9b492b、a1392c7、47905ae、e51a0d6)。

## 方案

### 提交 1:恢复自动修复与语义化定位方案
- **语义化定位替代硬编码锚点**:语言白名单改为通用 locale 数组打分识别(兼容单/双引号、语言增删、顺序变化);前端资源目录递归发现(兼容 v1/v2/hash 目录);主进程 bundle 按内容特征扫描(兼容 bundle 拆分)
- **分层降级**:语言资源+白名单为必需层,asar 注入为增强层;增强锚点失效自动退安全模式继续安装,不再全盘失败
- **更新后自动修复**:macOS root LaunchDaemon(静置 90 秒防在更新写入中途打补丁、失败按构建退避 6 小时、flock 防并发、payload root 专有防提权);Windows SYSTEM 计划任务 + pending-restore 断点续作
- **修复备份降级 bug**:恢复备份前校验版本,杜绝"更新后重装把客户端静默降级回旧版"
- **`--doctor --json`**:机器可读兼容性诊断
- 新增 11 个合成 fixture 单测 + 三平台 CI(`test.yml`),并修正 manifest 计数与实际资源脱节的存量问题(12325 → 16173)

### 提交 2:对抗性评审后的加固(11 项确认问题全部修复)
- **WatchPaths 事件触发**:LaunchDaemon 监听 `Contents/Info.plist`,官方更新后秒级修复,5 分钟轮询降为兜底
- **修复守护上下文退出 Claude 失效**:root 域裸 osascript 送不到用户 Aqua 会话(-600/-1743 被静默吞掉),改经 `launchctl asuser` 投递;仍在运行时如实记录"下次启动生效",不再误报修复完成
- **修复进程检测失效**:实测 macOS `pgrep -x Claude` 检测不到 Electron 主进程(argv 不可读),改为锚定 bundle 路径前缀匹配 helper 进程(实测 14/14 检出、诱饵进程零误报)
- **修复 doctor 盲区**:legacy 回退路径下锚点全灭仍报 `fullCompatible=true`(已实测复现),现补锚点复验
- **上游发版预警 `upstream-watch.yml`**:每 6 小时查询官方 update feed(`api.anthropic.com/api/desktop/darwin/universal/squirrel/update`),新版本发布当天自动下载做 doctor + 完整 dry-run 检测,失败**或静默降级安全模式**时自动开 issue——把破坏发现时间从"用户报 issue 后数天"压缩到"发版当天"(外部值经 env 注入防脚本注入,curl 带重试,按版本号去重)
- 日志轮转(1MB)、README 措辞同步、新增 6 个单测

## 验证

- 单元测试 17/17 通过(macOS/Python 3.14)
- 真机 Claude Desktop **1.24012.9** 完整 dry-run 通过(语义定位选中 `.vite/build/index.chunk-*.js`,1074 处替换,重签名+完整性校验全过)
- `--doctor` 正/负向验证(锚点缺失场景正确报不兼容)
- `install_windows.ps1` pwsh 7.6 语法解析 + `-LibraryMode` 核心函数(语义化追加/幂等/双引号风格)通过
- 进程检测、日志轮转在真实环境冒烟通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)