### PR TITLE
ci: 新增测试工作流（DOM 守卫测试 + 生成脚本语法检查 + 资源 JSON 校验）

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dom-translation-guards:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run DOM translation guard tests
+        run: python3 -m unittest -v tests.test_dom_translation_guards
+
+      - name: Compile patcher and tests
+        run: python3 -m py_compile scripts/patch_claude_zh_cn.py tests/test_dom_translation_guards.py
+
+      - name: Syntax-check generated macOS DOM script
+        run: |
+          python3 -c "import tests.test_dom_translation_guards as t; print(t.load_python_patcher().build_online_dom_translation_script('zh-CN', {'Settings': '设置'}))" | node --check
+
+      - name: Syntax-check materialized Windows DOM script
+        run: |
+          python3 -c "import tests.test_dom_translation_guards as t; print(t.materialize_windows_dom_script(t.extract_windows_dom_template()))" | node --check
+
+      - name: Validate resource JSON files
+        run: |
+          python3 - <<'PY'
+          import json, re, sys
+          from pathlib import Path
+          for path in sorted(Path("resources").glob("*.json")):
+              raw = path.read_text(encoding="utf-8")
+              keys = re.findall(r'^  "((?:[^"\\]|\\.)+)":', raw, re.M)
+              dupes = {k for k in keys if keys.count(k) > 1}
+              if dupes:
+                  sys.exit(f"{path}: duplicate keys {dupes}")
+              json.loads(raw)
+          print("All resource JSON files are valid with no duplicate keys.")
+          PY


### PR DESCRIPTION
## 变更说明

新增 `.github/workflows/tests.yml`，在 push 到 main、PR 和手动触发时运行：

1. `python3 -m unittest -v tests.test_dom_translation_guards` — DOM 翻译守卫测试（4/4）
2. `python3 -m py_compile` — 补丁脚本与测试的编译检查
3. 生成后的 macOS DOM 脚本 `node --check` 语法检查
4. 具象化后的 Windows DOM 脚本 `node --check` 语法检查
5. `resources/*.json` 全部资源文件校验：合法 JSON + 无重复键

## 动机

落实 PR #141 评审中的建议——此前 `tests/` 没有任何 CI 挂载，测试容易腐化；同时 #142/#143 这类翻译数据 PR 也可以从此自动挡住重复键和非法 JSON。

## 验证

- 5 条检查命令均已在本地逐一执行通过（macOS / Python 3.14 / Node 20）
- 工作流仅使用仓库自带的 Python 标准库与 runner 预装的 node，无第三方依赖
- 使用 `actions/checkout@v4` + `ubuntu-latest`，与仓库现有 workflow 风格一致