### PR TITLE
文档：添加 MIT 许可证

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 javaht
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 变更说明

- 在仓库根目录新增标准 MIT 许可证文本，版权行为 `Copyright (c) 2025 javaht`。
- 本 PR 仅提出采用标准 MIT 文本，不将这次变更称为恢复既有许可证。

## 验证

- 将 GitHub MIT 标准模板中的 `[year] [fullname]` 替换为 `2025 javaht` 后，逐字比对通过。
- `git diff --check` 通过。
- 变更范围仅有根目录 `LICENSE` 一个文件。

## 授权确认

请维护者在合并前确认：

- 项目选择 MIT 作为当前许可证；
- 版权年份 `2025` 和版权主体 `javaht` 符合维护者意图；
- 现有贡献者的授权足以让仓库中的既有贡献按 MIT 条款提供。

作为 #141 和 #142 的作者，MapleEve 确认自己在这两个 PR 中的原创贡献仍可按 MIT 提供；该确认仅代表 MapleEve，不代表其他贡献者。

本 PR 不授予 Claude 或 Anthropic 官方界面、字符串、截图、商标以及任何第三方材料的权利。

## 备注

- 历史提交 `94c7c5e` 曾出现相同的 MIT 文本，但同一 PR 后续将许可证改为 AGPL-3.0；因此该历史不是仓库当前采用 MIT 的证明。
- 本 PR 仅修改许可证文档，不改动代码、安装逻辑或翻译内容。
