### PR TITLE
Fix Windows DOM hook detection for 1.32885.1 split bundles (Closes #148)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Run DOM translation guard tests
         run: python3 -m unittest -v tests.test_dom_translation_guards
 
+      - name: Run Windows DOM hook scan tests
+        run: python3 -m unittest -v tests.test_windows_dom_hook
+
       - name: Compile patcher and tests
-        run: python3 -m py_compile scripts/patch_claude_zh_cn.py tests/test_dom_translation_guards.py
+        run: python3 -m py_compile scripts/patch_claude_zh_cn.py tests/test_dom_translation_guards.py tests/test_windows_dom_hook.py
 
       - name: Syntax-check generated macOS DOM script
         run: |

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1600,7 +1600,8 @@ function Find-OnlineDomTranslationHook {
     )
 
     $readyNeedle = "main_view_dom_ready"
-    $eventPattern = [System.Text.RegularExpressions.Regex]::new('\.webContents\.on\((?<quote>["''`])dom-ready\k<quote>,\(\)=>\{')
+    # 1.32 起 bundle 里 handler 写成 ((...))，旧版为 (...)，括号层数可选
+    $eventPattern = [System.Text.RegularExpressions.Regex]::new('\.webContents\.on\((?<quote>["''`])dom-ready\k<quote>,(?<paren>\(?)\(\)=>\{')
     $handlerCloseNeedle = "})"
 
     if (-not $Quiet) {
@@ -1630,6 +1631,10 @@ function Find-OnlineDomTranslationHook {
 
         $body = $Text.Substring($bodyStart, $handlerClose - $bodyStart).TrimEnd(";")
         $terminatorIndex = $handlerClose + $handlerCloseNeedle.Length
+        if (($eventMatch.Groups["paren"].Value -eq "(") -and ($terminatorIndex -lt $Text.Length) -and ([string]$Text[$terminatorIndex] -eq ")")) {
+            # 新版 bundle 用 ((...)) 包裹 handler，跳过外层右括号，链式分隔符在其后
+            $terminatorIndex += 1
+        }
         if (($body.Contains("{")) -or ($body.Contains("}")) -or ($terminatorIndex -ge $Text.Length)) {
             if (-not $Quiet) {
                 Write-Host "  [进度] 第 $checked 个 dom-ready handler 含嵌套代码或缺少结束分隔符，继续查找下一个..." -ForegroundColor DarkGray

--- a/tests/test_windows_dom_hook.py
+++ b/tests/test_windows_dom_hook.py
@@ -1,0 +1,111 @@
+r"""Regression tests for the Windows installer's online DOM translation hook scanner.
+
+Covers the bundle format change seen in Claude Desktop 1.32885.1, where the
+main-process bundle was split into index.chunk-*.js files and the dom-ready
+handler is registered as webContents.on(`dom-ready`,(()=>{...})) (arrow
+function wrapped in an extra paren pair), instead of the older
+webContents.on("dom-ready",()=>{...}) form.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_PATCHER = ROOT / "scripts" / "install_windows.ps1"
+
+# 1.32885.1-era shape: backtick event name, extra paren around the arrow,
+# ternary/nested-call body, comma-chain terminator. Structurally identical to
+# the real bundle, no Anthropic code copied.
+NEW_FORMAT = (
+    "c.webContents.on(`dom-ready`,(()=>{"
+    "let ok=canLoad();d=ok?Date.now():void 0,track(ok?c.webContents:null)"
+    "})),Jdn(c),a.contentView.addChildView(c);"
+)
+
+# Pre-1.32-era shape (e.g. 0.14.10): double-quoted event name, plain arrow,
+# trivial body, semicolon terminator.
+OLD_FORMAT = (
+    'r.webContents.on("dom-ready",()=>{a0()});'
+    'const n=y7({webPreferences:{preload:Be.join(se.app.getAppPath(),'
+    '".vite/build/findInPage.js")}});'
+)
+
+HARNESS = r'''
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+{PARAMS_AND_FUNCTIONS}
+$fixture = @'
+{FIXTURE}
+'@
+$result = Find-OnlineDomTranslationHook $fixture -Quiet
+[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+$result | ConvertTo-Json -Compress
+'''
+
+
+def find_function_region(source: str) -> str:
+    """Return the patcher's definitions without its executable main flow.
+
+    The script ends with an unconditional `param(...)` block plus function
+    definitions followed by a top-level `try {` main flow; we drop the param
+    block and everything from `try {` onward so the functions can be loaded
+    without running an install.
+    """
+    import re
+
+    main_flow = re.search(r"(?m)^try \{", source)
+    if main_flow is None:
+        raise AssertionError("could not locate main flow in install_windows.ps1")
+    body = source[: main_flow.start()]
+    lines = body.split("\n")
+    close = next(i for i, line in enumerate(lines) if line.strip() == ")")
+    return "\n".join(lines[close + 1 :])
+
+
+def run_hook_scan(fixture: str) -> dict:
+    pwsh = shutil.which("pwsh")
+    if pwsh is None:
+        raise unittest.SkipTest("pwsh not available")
+    source = WINDOWS_PATCHER.read_text(encoding="utf-8-sig")
+    functions = find_function_region(source)
+    harness = HARNESS.replace("{PARAMS_AND_FUNCTIONS}", functions).replace("{FIXTURE}", fixture)
+    proc = subprocess.run(
+        [pwsh, "-NoProfile", "-NonInteractive", "-Command", harness],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=120,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"pwsh failed ({proc.returncode}):\nstdout: {proc.stdout}\nstderr: {proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
+class WindowsDomHookScanTest(unittest.TestCase):
+    def test_new_bundle_parenthesized_handler(self):
+        result = run_hook_scan(NEW_FORMAT)
+        self.assertTrue(result["Success"], result)
+        self.assertEqual(result["Receiver"], "c")
+        self.assertEqual(
+            result["Body"],
+            "let ok=canLoad();d=ok?Date.now():void 0,track(ok?c.webContents:null)",
+        )
+        self.assertEqual(result["Terminator"], ",")
+        self.assertEqual(result["EventQuote"], "`")
+
+    def test_old_bundle_plain_handler_still_works(self):
+        result = run_hook_scan(OLD_FORMAT)
+        self.assertTrue(result["Success"], result)
+        self.assertEqual(result["Receiver"], "r")
+        self.assertEqual(result["Body"], "a0()")
+        self.assertEqual(result["Terminator"], ";")
+        self.assertEqual(result["EventQuote"], '"')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_windows_dom_hook.py
+++ b/tests/test_windows_dom_hook.py
@@ -66,19 +66,28 @@ def find_function_region(source: str) -> str:
 
 
 def run_hook_scan(fixture: str) -> dict:
+    import tempfile
+
     pwsh = shutil.which("pwsh")
     if pwsh is None:
         raise unittest.SkipTest("pwsh not available")
     source = WINDOWS_PATCHER.read_text(encoding="utf-8-sig")
     functions = find_function_region(source)
     harness = HARNESS.replace("{PARAMS_AND_FUNCTIONS}", functions).replace("{FIXTURE}", fixture)
-    proc = subprocess.run(
-        [pwsh, "-NoProfile", "-NonInteractive", "-Command", harness],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        timeout=120,
-    )
+    # 脚本体远大于单参数长度上限（Linux MAX_ARG_STRLEN），必须写文件用 -File 执行
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ps1", encoding="utf-8", delete=False) as tmp:
+        tmp.write(harness)
+        harness_path = tmp.name
+    try:
+        proc = subprocess.run(
+            [pwsh, "-NoProfile", "-NonInteractive", "-File", harness_path],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=120,
+        )
+    finally:
+        Path(harness_path).unlink(missing_ok=True)
     if proc.returncode != 0:
         raise AssertionError(
             f"pwsh failed ({proc.returncode}):\nstdout: {proc.stdout}\nstderr: {proc.stderr}"


### PR DESCRIPTION
## 问题（#148）

Claude Desktop 1.32885.1 安装/卸载失败，报错：

```
Could not find online claude.ai DOM translation injection point. Claude's bundle format may have changed.
```

## 根因

用官方 1.32885.1 产物（apt 源 `downloads.claude.ai` 的 deb，SHA256 与索引一致）解出 app.asar 取证对比：

- `.vite/build/index.js` 变成 **625 字节入口 stub**（Sentry 初始化 + `require` 两个 chunk），真正的主进程代码拆到 `index.chunk-*.js` 里（如 5.4MB 的 `index.chunk-CdfeLm1B.js`）；
- dom-ready 注册从旧版 `r.webContents.on("dom-ready",()=>{a0()})` 变成新版 `` c.webContents.on(`dom-ready`,(()=>{let e=l();...})) ``——**箭头函数外层多了括号 `((...))`**；
- `Find-OnlineDomTranslationHook` 的正则只匹配 `,()=>{`，扫到 0 个 handler → 旧锚点 `DIA()` 已不存在 → 回退到 625 字节 stub → 抛错。

## 修复

`scripts/install_windows.ps1` `Find-OnlineDomTranslationHook`：

1. 正则允许 handler 外层可选括号：`,(?<paren>\(?)?\(\)=>\{`（新旧两种写法都认）；
2. 匹配到外层括号时，跳过其右括号，从真正的链式分隔符（`,`）取终结符，保证注入后括号配平。

## 验证

- 新增 `tests/test_windows_dom_hook.py`（TDD）：新格式用例先红后绿，旧格式回归用例保持通过；已接入 CI（ubuntu runner 自带 pwsh）；
- 真实 1.32885.1 bundle：定位成功（receiver=`c`），`Resolve-MainProcessAsarTarget` 正确选中 `index.chunk-CdfeLm1B.js`（修复前回退 stub）；
- 注入区括号平衡 (0,0,0)，注入后与卸载还原后的代码均通过 `node --check`，还原结果与原代码行为一致（差异仅为 minifier 装饰性括号，语义等价）；
- 现有 `tests/test_dom_translation_guards` 4 个用例全部通过。

Closes #148