### PR TITLE
Fix macOS dom-ready anchor detection for 1.32885.1 split bundles

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,6 @@ jobs:
               json.loads(raw)
           print("All resource JSON files are valid with no duplicate keys.")
           PY
+
+      - name: Run macOS DOM hook scan tests
+        run: python3 -m unittest -v tests.test_macos_dom_hook

--- a/scripts/patch_claude_zh_cn.py
+++ b/scripts/patch_claude_zh_cn.py
@@ -868,8 +868,11 @@ def patch_online_locale_lock_in_asar(app: Path, lang_code: str) -> str:
 def find_main_view_dom_ready_handler(text: str) -> re.Match[str] | None:
     pattern = re.compile(
         r'(?P<web_contents>[A-Za-z_$][A-Za-z0-9_$]*\.webContents)'
-        r'\.on\((?P<quote>["\'`])dom-ready(?P=quote),\(\)=>\{'
-        r'(?P<body>[^{}]*)\}\)(?P<terminator>[;,])'
+        r'\.on\((?P<quote>["\'`])dom-ready(?P=quote),'
+        # Newer bundles wrap the arrow function in an extra pair of parens:
+        # .on(`dom-ready`,(()=>{...})). Accept both shapes, keeping them balanced.
+        r'(?P<wrap>\()?\(\)=>\{(?P<body>[^{}]*)\}\)(?(wrap)\))'
+        r'(?P<terminator>[;,])'
     )
     matches = [
         match

--- a/tests/test_macos_dom_hook.py
+++ b/tests/test_macos_dom_hook.py
@@ -1,0 +1,115 @@
+r"""Regression tests for the macOS patcher's dom-ready handler locator.
+
+Covers the bundle format change seen in Claude Desktop 1.32885.1, where the
+main-process bundle was split into index.chunk-*.js files and the dom-ready
+handler is registered as webContents.on(`dom-ready`,(()=>{...})) (arrow
+function wrapped in an extra paren pair), instead of the older
+webContents.on("dom-ready",()=>{...}) form.
+"""
+
+import shutil
+import subprocess
+import unittest
+
+from tests.test_dom_translation_guards import load_python_patcher
+
+# 1.32885.1-era shape: backtick event name, extra paren around the arrow,
+# ternary/nested-call body, comma-chain terminator. Structurally identical to
+# the real bundle, no Anthropic code copied.
+NEW_FORMAT = (
+    "c.webContents.on(`dom-ready`,(()=>{"
+    "let ok=canLoad();d=ok?Date.now():void 0,track(ok?c.webContents:null),done()"
+    "})),nextCall(c);"
+)
+
+# Pre-1.32-era shape: double-quoted event name, plain arrow, trivial body,
+# semicolon terminator.
+OLD_FORMAT = 'r.webContents.on("dom-ready",()=>{a0()});const n=setup();'
+
+
+def patch_text(patcher, text: str) -> str:
+    handler = patcher.find_main_view_dom_ready_handler(text)
+    assert handler is not None
+    injection = patcher.build_online_locale_main_process_script(
+        "zh-CN",
+        {"Settings": "设置"},
+        handler.group("web_contents"),
+        handler.group("body"),
+        handler.group("terminator"),
+        handler.group("quote"),
+    )
+    return text[: handler.start()] + injection + text[handler.end() :]
+
+
+class MacosDomReadyHookTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.patcher = load_python_patcher()
+
+    def test_new_split_bundle_handler_is_located(self):
+        handler = self.patcher.find_main_view_dom_ready_handler(NEW_FORMAT)
+        self.assertIsNotNone(handler)
+        self.assertEqual(handler.group("web_contents"), "c.webContents")
+        self.assertEqual(handler.group("quote"), "`")
+        self.assertEqual(handler.group("wrap"), "(")
+        self.assertEqual(handler.group("terminator"), ",")
+        self.assertIn("track(ok?c.webContents:null)", handler.group("body"))
+
+    def test_legacy_handler_still_matches(self):
+        handler = self.patcher.find_main_view_dom_ready_handler(OLD_FORMAT)
+        self.assertIsNotNone(handler)
+        self.assertEqual(handler.group("web_contents"), "r.webContents")
+        self.assertEqual(handler.group("quote"), '"')
+        self.assertIsNone(handler.group("wrap"))
+        self.assertEqual(handler.group("terminator"), ";")
+        self.assertEqual(handler.group("body"), "a0()")
+
+    def test_unbalanced_handler_parens_are_rejected(self):
+        # Guard against a partial match that would unbalance the bundle when
+        # the matched span is replaced by the injection.
+        for broken in (
+            "y.webContents.on(`dom-ready`,(()=>{z()}),",
+            "y.webContents.on(`dom-ready`,()=>{z()})),",
+        ):
+            with self.subTest(broken=broken):
+                self.assertIsNone(
+                    self.patcher.find_main_view_dom_ready_handler(broken)
+                )
+
+    def test_patch_round_trips_for_both_formats(self):
+        for name, source in (("new", NEW_FORMAT), ("legacy", OLD_FORMAT)):
+            with self.subTest(format=name):
+                patched = patch_text(self.patcher, source)
+                self.assertIn(self.patcher.ONLINE_LOCALE_MAIN_MARKER, patched)
+
+                reverted, had_patch = (
+                    self.patcher.strip_online_locale_main_process_patch(patched)
+                )
+                self.assertTrue(had_patch)
+                self.assertNotIn(
+                    self.patcher.ONLINE_LOCALE_MAIN_MARKER, reverted
+                )
+                # The patcher always emits the canonical unwrapped handler, so a
+                # wrapped source loses its decorative parens; re-patching the
+                # reverted text must then be a no-op.
+                self.assertEqual(patch_text(self.patcher, reverted), patched)
+
+    @unittest.skipUnless(shutil.which("node"), "node is required for syntax checks")
+    def test_patched_bundle_text_is_valid_javascript(self):
+        for name, source in (("new", NEW_FORMAT), ("legacy", OLD_FORMAT)):
+            with self.subTest(format=name):
+                patched = patch_text(self.patcher, source)
+                for label, text in (("patched", patched), ("source", source)):
+                    result = subprocess.run(
+                        ["node", "--check", "-"],
+                        input=text,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(
+                        result.returncode, 0, f"{label} {name}: {result.stderr}"
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

macOS 在 Claude Desktop 1.32885.1 上安装失败：

```
Selected main-process ASAR bundle: .vite/build/index.js
Could not find main view dom-ready anchor for online locale patch.
Claude's bundle format may have changed.
```

脚本在临时工作区打完前端补丁后于 `patch_online_locale_main_process` 抛出 `SystemExit`，`resign_app` / `verify` / `backup_and_replace` 都没执行，`/Applications/Claude.app` 保持原样——用户看到的现象是"跑了很久但完全没汉化"，且因为没走到备份步骤，也不会留下 `Claude.backup-before-zh-CN-*.app`。

这与 #148 / #149 是同一个根因在 macOS 侧的表现。#149 修的是 `scripts/install_windows.ps1`，本 PR 修 `scripts/patch_claude_zh_cn.py`，两者互不重叠。

## 根因

在真实 1.32885.1 的 `app.asar` 上取证（macOS，`Claude 1.32885.1`）：

- `.vite/build/index.js` 只剩 **625 字节**入口 stub（Sentry 初始化 + 两个 `require`），主进程代码拆进了 `index.chunk-*.js`；本机上是 5.5MB 的 `index.chunk-DKLMt2ZQ.js`（#149 取证的 Windows 产物是 `index.chunk-CdfeLm1B.js`，**chunk 哈希随构建变化，不能硬编码**）。
- dom-ready 注册写法变了，箭头函数外层多了一对括号：

  ```js
  // 旧: r.webContents.on("dom-ready",()=>{a0()});
  // 新: d.webContents.on(`dom-ready`,(()=>{let e=f();...,eQ()})),
  ```

- `find_main_view_dom_ready_handler` 的正则只认 `,()=>{`，匹配不到 → `find_main_process_asar_target` 的 `handler_matches` 为空 → 走 "Compatibility fallback for older Claude builds" 回退到 `ASAR_PATCH_TARGET`（即那个 625 字节 stub）→ 在 stub 里找锚点必然失败 → 抛错。

连带失效的还有一层筛选：该函数原本优先挑 "handler body 里含 `main_view_dom_ready` 字面量" 的匹配，但新版 bundle 里这个字符串被压缩进了 `nbr()` 的定义，body 里只剩函数调用。修好正则后，这一层退化到后续的 `pattern.search`，而目标文件里 `dom-ready` 只出现 1 次，定位仍然唯一，因此**无需改动 `find_main_process_asar_target`**。

## 修复

`find_main_view_dom_ready_handler` 正则允许可选的外层括号，用条件组 `(?P<wrap>\()?...(?(wrap)\))` 保证**成对**出现——括号不配平时不匹配，避免半截匹配被 injection 替换后破坏 bundle。

只改这一处。`build_online_locale_main_process_script` 本来就固定输出无外层括号的规范形式（语法等价），`strip_online_locale_main_process_patch` 的还原正则匹配的也正是这种形式，所以打补丁 / 卸载还原 / 重装链路都不受影响。

## 验证

**在真实 1.32885.1 的 `app.asar` 上（只读，不写回 `/Applications`）：**

| 检查项 | 结果 |
|---|---|
| `find_main_process_asar_target` | 选中 `.vite/build/index.chunk-DKLMt2ZQ.js`（修复前回退 stub） |
| 锚点定位 | 命中，`wrap=(`，`terminator=,` |
| 注入映射 | 8716 条 DOM 字符串 |
| 注入后语法 | `node --check` 通过 |
| 卸载还原 | `strip` 能识别并还原；与原文差异仅为 minifier 的 2 个装饰性括号，语义等价 |
| 重装幂等 | 还原后重新打补丁，输出逐字节相同 |

**实机安装：** 打上本补丁后完整走通 `install-mac.command` 选项 1，安装成功，界面正常汉化。

**新增 `tests/test_macos_dom_hook.py`（5 个用例，已接入 CI）：**

- 新格式（反引号 + 外层括号 + `,` 结尾）定位正确；对修复前的代码先红后绿
- 旧格式（双引号 + 无括号 + `;` 结尾）回归通过
- 括号不配平的畸形输入被拒绝
- 两种格式下 打补丁 → 还原 → 重打 幂等
- 两种格式下补丁产物 `node --check` 通过

fixture 为结构等价的自造代码，未复制 Anthropic 任何代码。

CI 步骤加在 workflow 末尾，刻意避开 #149 改动的区域，两个 PR 不冲突。现有 `tests.test_dom_translation_guards` 4 个用例保持通过。
