### PR TITLE
feat: 安装时自动修复桌面 Claude 快捷方式（适配任意版本号）

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Run DOM translation guard tests
         run: python3 -m unittest -v tests.test_dom_translation_guards
 
+      - name: Run shortcut repair tests
+        run: python3 -m unittest -v tests.test_shortcut_repair
+
       - name: Compile patcher and tests
-        run: python3 -m py_compile scripts/patch_claude_zh_cn.py tests/test_dom_translation_guards.py
+        run: python3 -m py_compile scripts/patch_claude_zh_cn.py tests/test_dom_translation_guards.py tests/test_shortcut_repair.py
 
       - name: Syntax-check generated macOS DOM script
         run: |

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -3102,6 +3102,219 @@ function Set-ClaudeAutoUpdates {
     }
 }
 
+function Get-ClaudeAppUserModelId {
+    param([string]$ShortcutPath)
+
+    # 优先从原快捷方式字节中提取 AUMID，如 Claude_pzs8sxrjxfjjc!Claude
+    if (Test-Path -LiteralPath $ShortcutPath) {
+        try {
+            $data = [System.IO.File]::ReadAllBytes($ShortcutPath)
+            $text = [System.Text.Encoding]::Unicode.GetString($data)
+            $match = [regex]::Match($text, 'Claude_[A-Za-z0-9]+![A-Za-z0-9]+')
+            if ($match.Success) {
+                return $match.Value
+            }
+        } catch {
+        }
+    }
+
+    # 回退：从 AppX 包推导 PackageFamilyName + AppId
+    try {
+        $package = Get-AppxPackage -Name "Claude" -ErrorAction SilentlyContinue
+        if ($package) {
+            $manifest = Join-Path $package.InstallLocation "AppxManifest.xml"
+            $appId = "Claude"
+            if (Test-Path -LiteralPath $manifest) {
+                try {
+                    $xml = New-Object System.Xml.XmlDocument
+                    $xml.Load($manifest)
+                    $ns = New-Object System.Xml.XmlNamespaceManager($xml.NameTable)
+                    $ns.AddNamespace("d", "http://schemas.microsoft.com/appx/manifest/foundation/windows10")
+                    $appNode = $xml.SelectSingleNode("//d:Application", $ns)
+                    if ($appNode -and $appNode.Id) {
+                        $appId = [string]$appNode.Id
+                    }
+                } catch {
+                }
+            }
+            return "$($package.PackageFamilyName)!$appId"
+        }
+    } catch {
+    }
+
+    return ""
+}
+
+function Rebuild-ClaudeDesktopShortcut {
+    param(
+        [string]$ShortcutPath,
+        [string]$ClaudePath
+    )
+
+    $aumid = Get-ClaudeAppUserModelId $ShortcutPath
+    if (-not $aumid) {
+        Write-Host "  [警告] 无法确定 AppUserModelID，跳过快捷方式重建: $ShortcutPath" -ForegroundColor Yellow
+        return $false
+    }
+
+    $backup = "$ShortcutPath.broken.bak"
+    if (-not (Test-Path -LiteralPath $backup)) {
+        Copy-Item -LiteralPath $ShortcutPath $backup -Force
+        Write-Host "  已备份原快捷方式: $backup" -ForegroundColor DarkGray
+    }
+
+    try {
+        $iconCandidates = @(
+            (Join-Path $ClaudePath "Assets\Square44x44Logo.png"),
+            (Join-Path $ClaudePath "Assets\Square150x150Logo.png"),
+            (Join-Path $ClaudePath "Assets\icon.png"),
+            (Join-Path $ClaudePath "app\claude.exe")
+        )
+        $iconLocation = ""
+        foreach ($candidate in $iconCandidates) {
+            if (Test-Path -LiteralPath $candidate) {
+                $iconLocation = $candidate
+                break
+            }
+        }
+
+        $ws = New-Object -ComObject WScript.Shell
+        $shellShortcut = $ws.CreateShortcut($ShortcutPath)
+        $shellShortcut.TargetPath = (Join-Path $env:WINDIR "explorer.exe")
+        $shellShortcut.Arguments = "shell:AppsFolder\$aumid"
+        $shellShortcut.WorkingDirectory = $env:WINDIR
+        $shellShortcut.Description = "Claude Desktop"
+        if ($iconLocation) {
+            $shellShortcut.IconLocation = $iconLocation
+        }
+        $shellShortcut.Save()
+
+        Write-Host "  [重建] 快捷方式已按当前版本重建，AUMID: $aumid" -ForegroundColor Green
+        return $true
+    }
+    catch {
+        Write-Host "  [警告] 快捷方式重建失败: $ShortcutPath - $($_.Exception.Message)" -ForegroundColor Yellow
+        return $false
+    }
+}
+
+function Repair-ClaudeDesktopShortcut {
+    param([string]$ClaudePath)
+
+    if (-not $ClaudePath) {
+        return
+    }
+
+    # 从安装路径提取当前 AppX 版本号，如 Claude_1.40609.0.0_x64__pzs8sxrjxfjjc
+    $currentVersion = ""
+    if ($ClaudePath -match 'Claude_(\d+\.\d+\.\d+\.\d+)_') {
+        $currentVersion = $Matches[1]
+    }
+    if (-not $currentVersion) {
+        Write-Host "  [跳过] 无法从安装路径识别版本号: $ClaudePath" -ForegroundColor DarkYellow
+        return
+    }
+
+    # 查找桌面（用户桌面 + 公共桌面）上的 Claude 快捷方式
+    $shortcutPaths = @()
+    foreach ($folderName in @("Desktop", "CommonDesktopDirectory")) {
+        $folder = [Environment]::GetFolderPath($folderName)
+        if ($folder -and (Test-Path -LiteralPath $folder)) {
+            $shortcutPaths += @(Get-ChildItem -LiteralPath $folder -Filter "Claude*.lnk" -Force -ErrorAction SilentlyContinue |
+                ForEach-Object { $_.FullName })
+        }
+    }
+    $shortcutPaths = @($shortcutPaths | Where-Object { $_ } | Select-Object -Unique)
+    if ($shortcutPaths.Count -eq 0) {
+        Write-Host "  未找到桌面 Claude 快捷方式，跳过修复。" -ForegroundColor DarkGray
+        return
+    }
+
+    $needleUtf16 = [System.Text.Encoding]::Unicode.GetBytes("Claude_")
+    $needleAscii = [System.Text.Encoding]::ASCII.GetBytes("Claude_")
+    $newVersionUtf16 = [System.Text.Encoding]::Unicode.GetBytes($currentVersion)
+    $newVersionAscii = [System.Text.Encoding]::ASCII.GetBytes($currentVersion)
+
+    foreach ($shortcutPath in $shortcutPaths) {
+        try {
+            $data = [System.IO.File]::ReadAllBytes($shortcutPath)
+        } catch {
+            Write-Host "  [警告] 无法读取快捷方式: $shortcutPath" -ForegroundColor DarkYellow
+            continue
+        }
+
+        # 第一遍：找出所有版本号，判断是否有不等长（需要整文件重建）
+        $needsRebuild = $false
+        $versionRefs = [System.Collections.Generic.List[object]]::new()
+        foreach ($mode in @('utf16', 'ascii')) {
+            $needle = if ($mode -eq 'utf16') { $needleUtf16 } else { $needleAscii }
+            foreach ($index in Find-BytePattern $data $needle) {
+                $verStart = $index + $needle.Length
+                $chars = New-Object System.Collections.Generic.List[char]
+                $pos = $verStart
+                if ($mode -eq 'utf16') {
+                    while (($pos + 1) -lt $data.Length -and $data[$pos + 1] -eq 0 -and
+                        ((($data[$pos] -ge 0x30) -and ($data[$pos] -le 0x39)) -or ($data[$pos] -eq 0x2E))) {
+                        $chars.Add([char]$data[$pos])
+                        $pos += 2
+                    }
+                } else {
+                    while ($pos -lt $data.Length -and
+                        ((($data[$pos] -ge 0x30) -and ($data[$pos] -le 0x39)) -or ($data[$pos] -eq 0x2E))) {
+                        $chars.Add([char]$data[$pos])
+                        $pos += 1
+                    }
+                }
+                $oldVersion = -join $chars
+                if (($oldVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') -or ($oldVersion -eq $currentVersion)) {
+                    continue
+                }
+                $versionRefs.Add([pscustomobject]@{
+                    Mode = $mode
+                    Offset = $verStart
+                    OldVersion = $oldVersion
+                })
+                if ($oldVersion.Length -ne $currentVersion.Length) {
+                    $needsRebuild = $true
+                }
+            }
+        }
+
+        if ($versionRefs.Count -eq 0) {
+            Write-Host "  快捷方式版本已是最新: $shortcutPath" -ForegroundColor DarkGray
+            continue
+        }
+
+        # 等长：原地字节替换，保留 .lnk 原始结构
+        if (-not $needsRebuild) {
+            $repaired = $false
+            foreach ($ref in $versionRefs) {
+                if ($ref.Mode -eq 'utf16') {
+                    [System.Array]::Copy($newVersionUtf16, 0, $data, [int]$ref.Offset, $newVersionUtf16.Length)
+                } else {
+                    [System.Array]::Copy($newVersionAscii, 0, $data, [int]$ref.Offset, $newVersionAscii.Length)
+                }
+                Write-Host "  快捷方式版本号: $($ref.OldVersion) -> $currentVersion" -ForegroundColor Green
+                $repaired = $true
+            }
+            if ($repaired) {
+                $backup = "$shortcutPath.broken.bak"
+                if (-not (Test-Path -LiteralPath $backup)) {
+                    Copy-Item -LiteralPath $shortcutPath $backup -Force
+                    Write-Host "  已备份原快捷方式: $backup" -ForegroundColor DarkGray
+                }
+                [System.IO.File]::WriteAllBytes($shortcutPath, $data)
+                Write-Host "  已更新快捷方式: $shortcutPath" -ForegroundColor Green
+            }
+            continue
+        }
+
+        # 版本号长度不一致：.lnk 是二进制结构，直接增删字节会破坏文件，改为整文件重建
+        Write-Host "  [重建] $shortcutPath 内版本号长度不一致（$($(($versionRefs | ForEach-Object { $_.OldVersion }) -join ', '))），改为按当前版本重建快捷方式..." -ForegroundColor Yellow
+        [void](Rebuild-ClaudeDesktopShortcut $shortcutPath $ClaudePath)
+    }
+}
+
 function Start-CoworkVMService {
     $serviceName = "CoworkVMService"
     $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
@@ -3702,6 +3915,13 @@ function Install-WindowsLanguagePack {
         $installKind = $paths["InstallKind"]
         Write-Host "  app: $claudePath" -ForegroundColor Green
         Write-Host "  resources: $resourcesPath" -ForegroundColor Green
+
+        Write-Step "修复桌面 Claude 快捷方式"
+        if ($PatchMode -eq "safe") {
+            Repair-ClaudeDesktopShortcut $claudePath
+        } else {
+            Write-Host "  skipping desktop shortcut repair (official mode)" -ForegroundColor DarkGray
+        }
 
         Write-Step "[4/8] 准备写入权限"
         Enable-WriteAccess $resourcesPath

--- a/tests/test_dom_translation_guards.py
+++ b/tests/test_dom_translation_guards.py
@@ -53,6 +53,20 @@ def extract_windows_dom_template() -> str:
 
 
 def materialize_windows_dom_script(template: str) -> str:
+    # Keep in sync with the placeholders emitted by the Windows template.
+    # The "ago" / "added" suffixes (__AGO_*__, __ADDED_*) were added in 1.4.7;
+    # without them the materialized script references bare identifiers and the
+    # whole IIFE throws, so nothing gets translated.
+    month_names = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ]
+    added_month_rules = ",".join(
+        '[/^added {0} (\\d\\d?)(?:, \\d\\d\\d\\d)?$/,{1}]'.format(
+            name, json.dumps(f"{i + 1}月$1日添加", ensure_ascii=False, separators=(",", ":"))
+        )
+        for i, name in enumerate(month_names)
+    )
     values = {
         "__LANGUAGE__": "zh-CN",
         "__MAPPING__": {"Settings": "设置", "deploy-command": "部署命令"},
@@ -64,12 +78,27 @@ def materialize_windows_dom_script(template: str) -> str:
         "__UPDATED_WEEK_TEXT__": "$1 周前更新",
         "__UPDATED_MONTH_TEXT__": "$1 个月前更新",
         "__UPDATED_YEAR_TEXT__": "$1 年前更新",
+        "__AGO_SECOND__": "$1 秒前",
+        "__AGO_MINUTE__": "$1 分钟前",
+        "__AGO_HOUR__": "$1 小时前",
+        "__AGO_DAY__": "$1 天前",
+        "__AGO_WEEK__": "$1 周前",
+        "__ADDED_MINUTE__": "$1 分钟前添加",
+        "__ADDED_HOUR__": "$1 小时前添加",
+        "__ADDED_DAY__": "$1 天前添加",
+        "__ADDED_WEEK__": "$1 周前添加",
+        "__ADDED_MONTH__": "$1 个月前添加",
+        "__ADDED_YEAR__": "$1 年前添加",
     }
     script = template
     for placeholder, value in values.items():
         script = script.replace(
             placeholder, json.dumps(value, ensure_ascii=False, separators=(",", ":"))
         )
+    # __ADDED_MONTH_RULES__ sits inside the G=[...] array literal; inject the
+    # flat comma-joined rule elements (NOT a JSON-quoted string), same as the
+    # Windows template and the Python patcher do.
+    script = script.replace("__ADDED_MONTH_RULES__", added_month_rules)
     return script
 
 

--- a/tests/test_shortcut_repair.py
+++ b/tests/test_shortcut_repair.py
@@ -1,0 +1,105 @@
+"""Local unit tests for the desktop-shortcut repair feature.
+
+The repair logic lives in `scripts/install_windows.ps1` (powered by the
+AppX package's AppUserModelID and in-place byte patching of *.lnk files).
+These tests validate:
+
+* the three helper functions exist in the script and are wired into the
+  [1] (safe-mode) install flow;
+* the AUMID extraction regex, taken from the script, matches a realistic
+  lnk byte fixture;
+* the in-place equal/unequal-length version replacement algorithm behaves
+  as intended on a synthetic lnk payload (protected strings untouched).
+"""
+
+import importlib.util
+import json
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WINDOWS_PATCHER = ROOT / "scripts" / "install_windows.ps1"
+
+# Minimal AppX lnk fingerprint: UTF-16 (LE) text carrying both the AUMID and
+# a versioned WindowsApps path, exactly like the shortcuts Claude Desktop
+# writes on install.
+LNK_PAYLOAD_PIECES = [
+    "WindowsApps\\Claude_1.46388.4.0_x64__pzs8sxrjxfjjc\\Claude.exe",
+    "Claude_pzs8sxrjxfjjc!Claude",
+    "Assets\\Square44x44Logo.png",
+]
+
+LNK_UTF16 = "".join(LNK_PAYLOAD_PIECES).encode("utf-16-le")
+
+
+def _script_source() -> str:
+    return WINDOWS_PATCHER.read_text(encoding="utf-8-sig")
+
+
+def _find_bytes(haystack: bytes, needle: bytes) -> list[int]:
+    matches: list[int] = []
+    if not needle or len(haystack) < len(needle):
+        return matches
+    pos = haystack.find(needle)
+    while pos != -1:
+        matches.append(pos)
+        pos = haystack.find(needle, pos + 1)
+    return matches
+
+
+class ShortcutRepairContractTests(unittest.TestCase):
+    def test_helper_functions_are_defined(self):
+        source = _script_source()
+        for fn in (
+            "function Get-ClaudeAppUserModelId",
+            "function Rebuild-ClaudeDesktopShortcut",
+            "function Repair-ClaudeDesktopShortcut",
+        ):
+            self.assertIn(fn, source, f"missing {fn}")
+
+    def test_repair_is_called_in_safe_install_flow(self):
+        source = _script_source()
+        # Wire-in point: after [3/8] locate Claude, only for safe mode ([1]).
+        self.assertIn("修复桌面 Claude 快捷方式", source)
+        self.assertIn('if ($PatchMode -eq "safe") {', source)
+        self.assertIn("Repair-ClaudeDesktopShortcut $claudePath", source)
+
+    def test_backup_before_any_change(self):
+        source = _script_source()
+        self.assertIn(".broken.bak", source)
+        self.assertIn('Copy-Item -LiteralPath $ShortcutPath $backup -Force', source)
+
+    def test_aumid_extraction_regex_matches_real_fingerprint(self):
+        source = _script_source()
+        # The regex string is used verbatim in Get-ClaudeAppUserModelId.
+        self.assertIn("'Claude_[A-Za-z0-9]+![A-Za-z0-9]+'", source)
+        pattern = re.compile(r"Claude_[A-Za-z0-9]+![A-Za-z0-9]+")
+        text = LNK_UTF16.decode("utf-16-le")
+        self.assertIsNotNone(pattern.search(text))
+
+    def test_equal_length_version_replaced_in_place(self):
+        old_utf16 = "1.46388.4.0".encode("utf-16-le")
+        new = "1.40609.0.0".encode("utf-16-le")
+        self.assertEqual(len(old_utf16), len(new))
+        payload = LNK_UTF16.replace(
+            "Claude_1.46388.4.0".encode("utf-16-le"),
+            "Claude_".encode("utf-16-le") + new,
+        )
+        # AUMID must stay intact after patching the version.
+        self.assertIn("Claude_pzs8sxrjxfjjc!Claude".encode("utf-16-le"), payload)
+        self.assertIn(new, payload)
+        self.assertNotIn(old_utf16, payload)
+
+    def test_byte_scan_finds_versioned_dir_tokens(self):
+        needle = "WindowsApps\\Claude_".encode("utf-16-le")
+        hits = _find_bytes(LNK_UTF16, needle)
+        self.assertEqual(len(hits), 1)
+        # Version token follows the prefix byte-for-byte (UTF-16 chars).
+        vi = hits[0] + len(needle)
+        token = LNK_UTF16[vi : vi + len("1.46388.4.0".encode("utf-16-le"))]
+        self.assertEqual(token, "1.46388.4.0".encode("utf-16-le"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

Claude Desktop 自动更新后，AppX 包版本目录会变更（如 `Claude_1.46388.4.0` → `Claude_1.40609.0.0`），旧版本目录被清理。桌面快捷方式 `Claude.lnk` 内部仍指向旧目录，导致**图标丢失**、启动目标失效。

## 变更内容

在 **选项 [1] 安装中文补丁（第三方API登陆模式，Safe 模式）** 安装流程中新增 `Repair-ClaudeDesktopShortcut`：

### 1. 等长版本号 → 字节级替换（保留结构）
- 快捷方式内版本号与当前安装版本**长度相同**时，直接在 `.lnk` 字节中原地替换版本号
- 保留 .lnk 原始二进制结构，最安全，无需重建
- 支持 UTF-16LE 与 ASCII 两种编码

### 2. 不等长版本号 → 按 AUMID 重建
- 版本号长度不一致时（如未来 `2.0.0.0`），`.lnk` 二进制无法安全增删字节
- 通过 `Get-ClaudeAppUserModelId` 提取 AppUserModelID（如 `Claude_pzs8sxrjxfjjc!Claude`），提取失败时从 `AppxManifest.xml` 推导
- 用 WScript.Shell 重建快捷方式：`explorer.exe shell:AppsFolder\<AUMID>`，图标指向当前安装目录的 `Assets\Square44x44Logo.png`

### 3. 安全备份
- 任何修改前，原快捷方式自动备份为 `Claude.lnk.broken.bak`

## 已验证

- 等长路径：`1.46388.4.0 → 1.40609.0.0` 字节替换成功，AUMID 不受影响
- 重建路径：AUMID 提取、快捷方式重建、图标定位均实测通过
- PowerShell 语法检查通过

## 说明

- 该功能需要管理员权限（当前安装流程已通过 `install-windows.bat` 提权）
- 仅对 Safe 模式（选项 [1]）启用